### PR TITLE
model extension: unique keys

### DIFF
--- a/model/schema/meta.yaml
+++ b/model/schema/meta.yaml
@@ -505,6 +505,23 @@ slots:
     range: boolean
     description: indicator that this is the root class in tree structures
 
+  compound_keys:
+    domain: class_definition
+    range: compound_key_definition
+    multivalued: true
+    inlined: true
+    description: Set of compound keys for this slot
+    mappings:
+      - owl:hasKey
+  
+  compound_key_slots:
+    domain: compound_key
+    multivalued: true
+    required: true
+    range: slot_definition
+    description: list of slot names that form a key
+    comments:
+      - We allow compound keys with a single compound_key slot, but at least one must be specified
 
   # -----------------------------------
   # Slot definition slots
@@ -628,12 +645,12 @@ slots:
     range: boolean
     inherited: true
     description: >-
-      True means that the key slot(s) uniquely identify the container. In future releases, it will be possible for there
-      to be compound keys, where several slots combine to produce a unique identifier
+      True means that the key slot(s) uniquely identify the container.
     comments:
+      - see also 'compound_key'
       - key is inherited
       - a given domain can have at most one key slot (restriction to be removed in the future)
-      - identifiers and keys are mutually exclusive.  A given domain cannot have bot
+      - identifiers and keys are mutually exclusive.  A given domain cannot have both
       - a key slot is automatically required.  Keys cannot be optional
 
   identifier:
@@ -1109,6 +1126,27 @@ classes:
       - text
       - description
       - meaning
+      - alt_descriptions
+      - deprecated
+      - todos
+      - notes
+      - comments
+      - examples
+      - in_subset
+      - from_schema
+      - imported_from
+      - see_also
+      - deprecated element has exact replacement
+      - deprecated element has possible replacement
+
+  compound_key:
+    description: a collection of slots whose values uniquely identify an instance of a class
+    mixins:
+      - extensible
+      - annotatable
+    slots:
+      - description
+      - compound_key_slots
       - alt_descriptions
       - deprecated
       - todos

--- a/model/schema/meta.yaml
+++ b/model/schema/meta.yaml
@@ -505,23 +505,21 @@ slots:
     range: boolean
     description: indicator that this is the root class in tree structures
 
-  compound_keys:
+  unique_keys:
     domain: class_definition
-    range: compound_key_definition
+    range: unique_key_definition
     multivalued: true
     inlined: true
-    description: Set of compound keys for this slot
+    description: Set of unique keys for this slot
     mappings:
       - owl:hasKey
   
-  compound_key_slots:
-    domain: compound_key
+  unique_key_slots:
+    domain: unique_key
     multivalued: true
     required: true
     range: slot_definition
     description: list of slot names that form a key
-    comments:
-      - We allow compound keys with a single compound_key slot, but at least one must be specified
 
   # -----------------------------------
   # Slot definition slots
@@ -647,7 +645,7 @@ slots:
     description: >-
       True means that the key slot(s) uniquely identify the container.
     comments:
-      - see also 'compound_key'
+      - see also 'unique_key'
       - key is inherited
       - a given domain can have at most one key slot (restriction to be removed in the future)
       - identifiers and keys are mutually exclusive.  A given domain cannot have both
@@ -1139,14 +1137,14 @@ classes:
       - deprecated element has exact replacement
       - deprecated element has possible replacement
 
-  compound_key:
+  unique_key:
     description: a collection of slots whose values uniquely identify an instance of a class
     mixins:
       - extensible
       - annotatable
     slots:
       - description
-      - compound_key_slots
+      - unique_key_slots
       - alt_descriptions
       - deprecated
       - todos

--- a/model/schema/meta.yaml
+++ b/model/schema/meta.yaml
@@ -507,13 +507,13 @@ slots:
 
   unique_keys:
     domain: class_definition
-    range: unique_key_definition
+    range: unique_key
     multivalued: true
     inlined: true
     description: Set of unique keys for this slot
     mappings:
       - owl:hasKey
-  
+
   unique_key_slots:
     domain: unique_key
     multivalued: true
@@ -906,19 +906,10 @@ slots:
 # Classes                         #
 #==================================
 classes:
-  element:
-    description: a named element in the model
-    abstract: true
-    mixins:
-      - extensible
-      - annotatable
+  CommonMetadata:
+    description: Generic metadata shared across definitions
+    mixin: true
     slots:
-      - name
-      - id_prefixes
-      - definition_uri
-      - aliases
-      - local_names
-      - mappings
       - description
       - alt_descriptions
       - deprecated
@@ -930,13 +921,28 @@ classes:
       - from_schema
       - imported_from
       - see_also
+      - deprecated element has exact replacement
+      - deprecated element has possible replacement
+
+  element:
+    description: a named element in the model
+    abstract: true
+    mixins:
+      - extensible
+      - annotatable
+      - CommonMetadata
+    slots:
+      - name
+      - id_prefixes
+      - definition_uri
+      - aliases
+      - local_names
+      - mappings
       - exact mappings
       - close mappings
       - related mappings
       - narrow mappings
       - broad mappings
-      - deprecated element has exact replacement
-      - deprecated element has possible replacement
     see_also:
       - https://en.wikipedia.org/wiki/Data_element
 
@@ -1115,6 +1121,7 @@ classes:
     mixins:
       - extensible
       - annotatable
+      - CommonMetadata
     slot_usage:
       is_a:
         range: permissible_value
@@ -1124,18 +1131,6 @@ classes:
       - text
       - description
       - meaning
-      - alt_descriptions
-      - deprecated
-      - todos
-      - notes
-      - comments
-      - examples
-      - in_subset
-      - from_schema
-      - imported_from
-      - see_also
-      - deprecated element has exact replacement
-      - deprecated element has possible replacement
 
   unique_key:
     description: a collection of slots whose values uniquely identify an instance of a class
@@ -1143,20 +1138,7 @@ classes:
       - extensible
       - annotatable
     slots:
-      - description
       - unique_key_slots
-      - alt_descriptions
-      - deprecated
-      - todos
-      - notes
-      - comments
-      - examples
-      - in_subset
-      - from_schema
-      - imported_from
-      - see_also
-      - deprecated element has exact replacement
-      - deprecated element has possible replacement
 
 
 #==================================

--- a/model/schema/meta.yaml
+++ b/model/schema/meta.yaml
@@ -906,7 +906,7 @@ slots:
 # Classes                         #
 #==================================
 classes:
-  CommonMetadata:
+  common_metadata:
     description: Generic metadata shared across definitions
     mixin: true
     slots:
@@ -930,7 +930,7 @@ classes:
     mixins:
       - extensible
       - annotatable
-      - CommonMetadata
+      - common_metadata
     slots:
       - name
       - id_prefixes
@@ -1121,7 +1121,7 @@ classes:
     mixins:
       - extensible
       - annotatable
-      - CommonMetadata
+      - common_metadata
     slot_usage:
       is_a:
         range: permissible_value


### PR DESCRIPTION
This introduces compound keys 

need to add tests

this example should illustrate concept:

```
classes:
  isotope:
    slots:
      - id
      - atomic number
      - neutron number
      - symbol
   compound_keys:
     proton_neutron_key:
       unique_for: isotope
       primary: false
       compound_key_slots:
         - atomic number
         - neutron number
    symbol uniqueness:
      unique_for: isotope
       primary: false
      compound_key_slots:
         - symbol

slots:
   id:
    identifier: true
```

See https://github.com/linkml/linkml/issues/42