### PR TITLE
Add version slot to be included in owl subset

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -340,6 +340,8 @@ slots:
     domain: schema_definition
     description: particular version of schema
     slot_uri: pav:version
+    in_subset:
+      - owl
     mappings:
       - schema:schemaVersion
 


### PR DESCRIPTION
This is to ensure that `version` slot is part of the OWL export since only those metamodel slots that are part of owl subset are exported by `gen-owl`.

Related to https://github.com/linkml/linkml/issues/285