### PR TITLE
Allow "pattern" to be used with type definitions

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -785,7 +785,7 @@ slots:
     inherited: true
 
   pattern:
-    domain: slot_definition
+    domain: definition
     range: string
     description: the string value of the slot must conform to this regular expression
     inherited: true
@@ -1027,6 +1027,7 @@ classes:
       - base
       - type_uri
       - repr
+      - pattern
 
   subset_definition:
     description: the name and description of a subset


### PR DESCRIPTION
Rationale: we may want to use the same regex for all slots that point to the same type.

```yaml
types:
  gene_symbol:
    base: str
    pattern: "^\\S+$"
 email:
    base str:
      pattern: "^\\S+@\\S+"
```

once implemented the json schema generation would change so that any slot that has a range with a pattern, treat as if the pattern were on that slot.

If there is a pattern on both slot and type, then we prioritize slot