### PR TITLE
clarify use of rdf:Resource as a type_uri

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1078,6 +1078,7 @@ slots:
     comments:
       - uri is typically drawn from the set of URI's defined in OWL (https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Datatype_Maps)
       - every root type must have a type uri
+      - A uri may also have value rdfs:Resource, in which case the rdf serialization will be as a Resource and not a Literal
 
   repr:
     domain: type_definition


### PR DESCRIPTION
See https://github.com/linkml/linkml/issues/450

Implemented here: https://github.com/linkml/linkml-runtime/pull/66