### PR TITLE
#59 move mention of ISO 11179 from description to see_also

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -324,9 +324,11 @@ slots:
     domain: permissible_value
     range: uriorcurie
     description: >-
-      the value meaning (in the 11179 sense) of a permissible value
+      the value meaning of a permissible value
     notes:
       - we may want to change the range of this (and other) elements in the model to an entitydescription type construct
+    see_also:
+      - https://en.wikipedia.org/wiki/ISO/IEC_11179
 
   # -----------------------------------
   # Schema definition slots


### PR DESCRIPTION
permissible_value.meaning.Description was
> the value meaning (in the 11179 sense) of a permissible value

I moved the mention of ISO 11179 into a see_also of https://en.wikipedia.org/wiki/ISO/IEC_11179
