### PR TITLE
Moving inlining metaslots to slot_expression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ docserve: gen-docs
 # ---------------------------------------
 # VALIDATION
 # ---------------------------------------
-EXAMPLES = relational-roles rules slot-group path unique-key
+EXAMPLES = relational-roles rules slot-group path unique-key inlining-union
 
 all-validate: $(patsubst %, validate-%, $(EXAMPLES))
 validate-%: examples/%-example.yaml

--- a/examples/inlining-union-example.yaml
+++ b/examples/inlining-union-example.yaml
@@ -1,0 +1,33 @@
+id: https://w3id.org/linkml/examples/inlining-union
+name: inlining-union
+license: https://creativecommons.org/publicdomain/zero/1.0/
+see_also:
+  - https://github.com/linkml/linkml/issues/664
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://w3id.org/linkml/examples/inlining-union
+
+default_prefix: ex
+default_range: string
+
+default_curi_maps:
+    - semweb_context
+
+
+imports:
+  - linkml:types
+
+#==================================
+# Classes                         #
+#==================================
+
+classes:
+  Foo:
+
+slots:
+  my_slot:
+    range: Foo
+    any_of:
+      - inlined: true
+      - inlined: false

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -2028,6 +2028,8 @@ classes:
       - range_expression
       - required
       - recommended
+      - inlined
+      - inlined_as_list
       - minimum_value
       - maximum_value
       - pattern
@@ -2083,8 +2085,6 @@ classes:
       - inherited
       - readonly
       - ifabsent
-      - inlined
-      - inlined_as_list
       - list_elements_unique
       - list_elements_ordered
       - shared


### PR DESCRIPTION
This allows them to be used in boolean expressions as well as direct slot attributes. See https://github.com/linkml/linkml/issues/664