### PR TITLE
rules example fixes

### DIFF
--- a/examples/rules-example.yaml
+++ b/examples/rules-example.yaml
@@ -31,12 +31,26 @@ emit_prefixes:
 imports:
   - linkml:types
 
+#==================================
+# Types                           #
+#==================================
+types:
+  AlternativeEnum:
+    typeof: uriorcurie
+    exactly_one_of:
+      - equals_string: schema:foo
+      - equals_string: schema:bar
+  
 
 #==================================
 # Slots                           #
 #==================================
 slots:
   id:
+  name:
+    range: string
+  employer_name:
+    range: string
   primary_address:
     range: Address
   street_address:
@@ -44,8 +58,11 @@ slots:
   postal_code:
   telephone:
   fiction_status:
+  slot A:
+  slot B:
+  slot C:
   age:
-    range: int
+    range: integer
   encodes:
     range: SeqFeature
   owns:
@@ -65,7 +82,7 @@ slots:
     any_of:
       - range: MissingValueEnum
       - range: VitalStatusEnum
-  familial_relationship:
+  familial_relationships:
     abstract: true
   parents:
     is_a: familial_relationships
@@ -80,6 +97,24 @@ slots:
     is_a: familial_relationships
     inverse: ancestors
     transitive_form_of: children
+  resident_of:
+    # remember to provide a range here, even though
+    # it could be inferred from the any_of, good to be explicit
+    range: uriorcurie
+    # any_of is the same as exactly_one_of unless multivalued=true
+    any_of:
+      - equals_string: geonames:1
+      - equals_string: geonames:2
+  resident_of_using_classes:
+    # remember to provide a range here, even though
+    # it could be inferred from the any_of, good to be explicit
+    range: CountryCode
+    inlined: false ## not required but just for illustration
+    # any_of is the same as exactly_one_of unless multivalued=true
+    any_of:
+      - equals_string: geonames:1
+      - equals_string: geonames:2
+  
 
     
 #==================================
@@ -87,6 +122,16 @@ slots:
 #==================================
 
 classes:
+
+  ControlledTerm:
+    attributes:
+      id:
+        identifier: true
+        range: uriorcurie
+      label:
+  CountryCode:
+    is_a: ControlledTerm
+  
   # https://json-schema.org/understanding-json-schema/reference/conditionals.html
   Address:
     slots:


### PR DESCRIPTION
- fixed doc typo: linkml.utils=>linkml_runtime.utils
- adding more examples for any_of
