### PR TITLE
Fix link in navigation to SpecificationSubset.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,7 @@ nav:
       Profiles:
         - MinimalSubset: MinimalSubset.md
         - BasicSubset: BasicSubset.md
-        - SpecificationProfile: SpecificationProfile.md
+        - SpecificationSubset: SpecificationSubset.md
         - RelationalModelProfile: RelationalModelProfile.md
         - ObjectOrientedProfile: ObjectOrientedProfile.md
         - OwlProfile: OwlProfile.md


### PR DESCRIPTION
Should the rebuilt docs also be committed or are they build in a CI job? I could not yet build them on windows.