### PR TITLE
Fix python artifact generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ deploy: gendoc mkd-gh-deploy
 # generates all project files
 # and updates the artifacts in linkml-model
 gen-project: $(PYMODEL)
-	$(RUN) gen-project -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
+	$(RUN) gen-project -d $(DEST) --config-file gen_project_config.yaml $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
 	cp -r $(DEST)/* $(PYMODEL)
 	rm -r $(PYMODEL)/docs
 

--- a/gen_project_config.yaml
+++ b/gen_project_config.yaml
@@ -1,0 +1,4 @@
+generator_args:
+  python:
+    genmeta: True
+    mergeimports: False

--- a/linkml_model/graphql/meta.graphql
+++ b/linkml_model/graphql/meta.graphql
@@ -1,5 +1,3 @@
-# metamodel_version: 1.7.0
-# version: 2.0.0
 type AltDescription
   {
     source: String!
@@ -144,6 +142,7 @@ type AnonymousSlotExpression implements SlotExpression
     structuredPattern: PatternExpression
     unit: UnitOfMeasure
     implicitPrefix: String
+    valuePresence: PresenceEnum
     equalsString: String
     equalsStringIn: [String]
     equalsNumber: Integer
@@ -151,7 +150,7 @@ type AnonymousSlotExpression implements SlotExpression
     minimumCardinality: Integer
     maximumCardinality: Integer
     hasMember: AnonymousSlotExpression
-    allMembers: [SlotDefinition]
+    allMembers: AnonymousSlotExpression
     noneOf: [AnonymousSlotExpression]
     exactlyOneOf: [AnonymousSlotExpression]
     anyOf: [AnonymousSlotExpression]
@@ -818,7 +817,7 @@ type SlotDefinition implements SlotExpression
     pathRule: PathExpression
     disjointWith: [SlotDefinition]
     childrenAreMutuallyDisjoint: Boolean
-    unionOf: [TypeDefinition]
+    unionOf: [SlotDefinition]
     isA: SlotDefinition
     mixins: [SlotDefinition]
     applyTo: [SlotDefinition]
@@ -835,6 +834,7 @@ type SlotDefinition implements SlotExpression
     structuredPattern: PatternExpression
     unit: UnitOfMeasure
     implicitPrefix: String
+    valuePresence: PresenceEnum
     equalsString: String
     equalsStringIn: [String]
     equalsNumber: Integer
@@ -842,7 +842,7 @@ type SlotDefinition implements SlotExpression
     minimumCardinality: Integer
     maximumCardinality: Integer
     hasMember: AnonymousSlotExpression
-    allMembers: [SlotDefinition]
+    allMembers: AnonymousSlotExpression
     noneOf: [AnonymousSlotExpression]
     exactlyOneOf: [AnonymousSlotExpression]
     anyOf: [AnonymousSlotExpression]
@@ -864,6 +864,7 @@ interface SlotExpression
     structuredPattern: PatternExpression
     unit: UnitOfMeasure
     implicitPrefix: String
+    valuePresence: PresenceEnum
     equalsString: String
     equalsStringIn: [String]
     equalsNumber: Integer
@@ -871,7 +872,7 @@ interface SlotExpression
     minimumCardinality: Integer
     maximumCardinality: Integer
     hasMember: AnonymousSlotExpression
-    allMembers: [SlotDefinition]
+    allMembers: AnonymousSlotExpression
     noneOf: [AnonymousSlotExpression]
     exactlyOneOf: [AnonymousSlotExpression]
     anyOf: [AnonymousSlotExpression]
@@ -1061,5 +1062,4 @@ type UnitOfMeasure
     hasQuantityKind: Uriorcurie
     iec61360code: String
   }
-
 

--- a/linkml_model/jsonld/meta.context.jsonld
+++ b/linkml_model/jsonld/meta.context.jsonld
@@ -1,5 +1,5 @@
 {
-   "_comments": "Auto generated from meta.yaml by jsonldcontextgen.py version: 0.1.1\n    Generation date: 2022-07-14T00:56:15\n    Schema: meta\n    metamodel version: 1.7.0\n    model version: 2.0.0\n    \n    id: https://w3id.org/linkml/meta\n    description: The metamodel for schemas defined using the Linked Data Modeling Language framework.\n\nFor more information on LinkML, see [linkml.io](https://linkml.io)\n\nCore metaclasses:\n\n* [SchemaDefinition](https://w3id.org/linkml/SchemaDefinition)\n* [ClassDefinition](https://w3id.org/linkml/ClassDefinition)\n* [SlotDefinition](https://w3id.org/linkml/SlotDefinition)\n* [TypeDefinition](https://w3id.org/linkml/TypeDefinition)\n\nEvery LinkML model instantiates SchemaDefinition, all classes in\nthe model instantiate ClassDefinition, and so on\n\nNote that the LinkML metamodel instantiates itself.\n\nFor a non-normative introduction to LinkML schemas, see the tutorial\nand schema guide on [linkml.io/linkml].\n\nFor canonical reference documentation on any metamodel construct,\nrefer to the official URI for each construct, e.g.\n[https://w3id.org/linkml/is_a](https://w3id.org/linkml/is_a)\n    license: https://creativecommons.org/publicdomain/zero/1.0/\n    ",
+   "_comments": "Auto generated from meta.yaml by jsonldcontextgen.py version: 0.1.1\n    Generation date: 2022-12-09T14:56:37\n    Schema: meta\n    metamodel version: 1.7.0\n    model version: 2.0.0\n    \n    id: https://w3id.org/linkml/meta\n    description: The metamodel for schemas defined using the Linked Data Modeling Language framework.\n\nFor more information on LinkML:\n\n* [linkml.io](https://linkml.io) main website\n* [specification](https://linkml.io/linkml-model/docs/specification/)\n\nLinkML is self-describing. Every LinkML schema consists of elements\nthat instantiate classes in this metamodel.\n\nCore metaclasses:\n\n* [SchemaDefinition](https://w3id.org/linkml/SchemaDefinition)\n* [ClassDefinition](https://w3id.org/linkml/ClassDefinition)\n* [SlotDefinition](https://w3id.org/linkml/SlotDefinition)\n* [TypeDefinition](https://w3id.org/linkml/TypeDefinition)\n\nThere are many subsets of *profiles* of the metamodel, for different purposes:\n\n* [MinimalSubset](https://w3id.org/linkml/MinimalSubset)\n* [BasicSubset](https://w3id.org/linkml/BasicSubset)\n* [BasicSubset](https://w3id.org/linkml/BasicSubset)\n\nFor canonical reference documentation on any metamodel construct,\nrefer to the official URI for each construct, e.g.\n[https://w3id.org/linkml/is_a](https://w3id.org/linkml/is_a)\n    license: https://creativecommons.org/publicdomain/zero/1.0/\n    ",
    "@context": {
       "IAO": {
          "@id": "http://purl.obolibrary.org/obo/IAO_",
@@ -379,11 +379,20 @@
          "@type": "@id",
          "@id": "sh:condition"
       },
+      "prefix_prefix": {
+         "@id": "sh:prefix"
+      },
       "prefix_reference": {
-         "@type": "@id"
+         "@type": "@id",
+         "@id": "sh:namespace"
       },
       "prefixes": {
-         "@type": "@id"
+         "@type": "@id",
+         "@id": "sh:declare"
+      },
+      "publisher": {
+         "@type": "@id",
+         "@id": "dcterms:publisher"
       },
       "pv_formula": {
          "@context": {
@@ -594,4 +603,3 @@
       }
    }
 }
-

--- a/linkml_model/jsonschema/meta.schema.json
+++ b/linkml_model/jsonschema/meta.schema.json
@@ -118,6 +118,7 @@
          "description": "",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -133,7 +134,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -231,7 +233,7 @@
                "type": "array"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent class or slot from which inheritable metaslots are propagated from. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
                "type": "string"
             },
             "mappings": {
@@ -385,16 +387,15 @@
          "description": "",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
                "type": "array"
             },
             "all_members": {
-               "additionalProperties": {
-                  "$ref": "#/$defs/SlotDefinition__identifier_optional"
-               },
-               "description": "the value of the multiavlued slot is a list where all elements conform to the specified values.\nthis defines a dynamic class with named slots according to matching constraints\n\nE.g to state that all members of a list are between 1 and 10\n```\nall_members:\n  x:\n    range: integer\n    minimum_value: 10\n    maximum_value: 10\n```"
+               "$ref": "#/$defs/AnonymousSlotExpression",
+               "description": "the value of the slot is multivalued with all members satisfying the condition"
             },
             "all_of": {
                "description": "holds if all of the expressions hold",
@@ -406,7 +407,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -514,7 +516,7 @@
             },
             "has_member": {
                "$ref": "#/$defs/AnonymousSlotExpression",
-               "description": "the values of the slot is multivalued with at least one member satisfying the condition"
+               "description": "the value of the slot is multivalued with at least one member satisfying the condition"
             },
             "implicit_prefix": {
                "description": "Causes the slot value to be interpreted as a uriorcurie after prefixing with this string",
@@ -653,6 +655,10 @@
             "unit": {
                "$ref": "#/$defs/UnitOfMeasure",
                "description": "an encoding of a unit"
+            },
+            "value_presence": {
+               "$ref": "#/$defs/PresenceEnum",
+               "description": "if true then a value must be present (for lists there must be at least one value). If false then a value must be absent (for lists, must be empty)"
             }
          },
          "required": [],
@@ -737,13 +743,14 @@
       },
       "ClassDefinition": {
          "additionalProperties": false,
-         "description": "the definition of a class or interface",
+         "description": "an element whose instances are complex objects that may have slot-value assignments",
          "properties": {
             "abstract": {
-               "description": "an abstract class is a high level class or slot that is typically used to group common slots together and cannot be directly instantiated.",
+               "description": "Indicates the class or slot cannot be directly instantiated and is intended for grouping and specifying core inherited metaslots",
                "type": "boolean"
             },
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -759,7 +766,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -799,7 +807,7 @@
                "type": "boolean"
             },
             "class_uri": {
-               "description": "URI of the class in an RDF environment",
+               "description": "URI of the class that provides a semantic interpretation of the element in a linked data context. The URI may come from any namespace and may be shared between schemas",
                "type": "string"
             },
             "classification_rules": {
@@ -923,7 +931,7 @@
                "type": "array"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent class from which inheritable metaslots are propagated",
                "type": "string"
             },
             "last_updated_on": {
@@ -944,11 +952,11 @@
                "type": "array"
             },
             "mixin": {
-               "description": "this slot or class can only be used as a mixin.",
+               "description": "Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins.",
                "type": "boolean"
             },
             "mixins": {
-               "description": "List of definitions to be mixed in. Targets may be any definition of the same type",
+               "description": "A collection of secondary parent mixin classes from which inheritable metaslots are propagated",
                "items": {
                   "type": "string"
                },
@@ -1026,10 +1034,10 @@
                "additionalProperties": {
                   "$ref": "#/$defs/SlotDefinition__identifier_optional"
                },
-               "description": "the redefinition of a slot in the context of the containing class definition."
+               "description": "the refinement of a slot in the context of the containing class definition."
             },
             "slots": {
-               "description": "list of slot names that are applicable to a class",
+               "description": "collection of slot names that are applicable to a class",
                "items": {
                   "type": "string"
                },
@@ -1084,7 +1092,7 @@
                "additionalProperties": {
                   "$ref": "#/$defs/UniqueKey__identifier_optional"
                },
-               "description": "Set of unique keys for this slot"
+               "description": "A collection of unique keys for this class. Unique keys may be singular or compound."
             },
             "values_from": {
                "description": "The identifier of a \"value set\" -- a set of identifiers that form the possible values for the range of a slot. Note: this is different than 'subproperty_of' in that 'subproperty_of' is intended to be a single ontology term while 'values_from' is the identifier of an entire value set.  Additionally, this is different than an enumeration in that in an enumeration, the values of the enumeration are listed directly in the model itself. Setting this property on a slot does not guarantee an expansion of the ontological hiearchy into an enumerated list of possible values in every serialization of the model.",
@@ -1102,13 +1110,14 @@
       },
       "ClassDefinition__identifier_optional": {
          "additionalProperties": false,
-         "description": "the definition of a class or interface",
+         "description": "an element whose instances are complex objects that may have slot-value assignments",
          "properties": {
             "abstract": {
-               "description": "an abstract class is a high level class or slot that is typically used to group common slots together and cannot be directly instantiated.",
+               "description": "Indicates the class or slot cannot be directly instantiated and is intended for grouping and specifying core inherited metaslots",
                "type": "boolean"
             },
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -1124,7 +1133,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -1164,7 +1174,7 @@
                "type": "boolean"
             },
             "class_uri": {
-               "description": "URI of the class in an RDF environment",
+               "description": "URI of the class that provides a semantic interpretation of the element in a linked data context. The URI may come from any namespace and may be shared between schemas",
                "type": "string"
             },
             "classification_rules": {
@@ -1288,7 +1298,7 @@
                "type": "array"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent class from which inheritable metaslots are propagated",
                "type": "string"
             },
             "last_updated_on": {
@@ -1309,11 +1319,11 @@
                "type": "array"
             },
             "mixin": {
-               "description": "this slot or class can only be used as a mixin.",
+               "description": "Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins.",
                "type": "boolean"
             },
             "mixins": {
-               "description": "List of definitions to be mixed in. Targets may be any definition of the same type",
+               "description": "A collection of secondary parent mixin classes from which inheritable metaslots are propagated",
                "items": {
                   "type": "string"
                },
@@ -1391,10 +1401,10 @@
                "additionalProperties": {
                   "$ref": "#/$defs/SlotDefinition__identifier_optional"
                },
-               "description": "the redefinition of a slot in the context of the containing class definition."
+               "description": "the refinement of a slot in the context of the containing class definition."
             },
             "slots": {
-               "description": "list of slot names that are applicable to a class",
+               "description": "collection of slot names that are applicable to a class",
                "items": {
                   "type": "string"
                },
@@ -1449,7 +1459,7 @@
                "additionalProperties": {
                   "$ref": "#/$defs/UniqueKey__identifier_optional"
                },
-               "description": "Set of unique keys for this slot"
+               "description": "A collection of unique keys for this class. Unique keys may be singular or compound."
             },
             "values_from": {
                "description": "The identifier of a \"value set\" -- a set of identifiers that form the possible values for the range of a slot. Note: this is different than 'subproperty_of' in that 'subproperty_of' is intended to be a single ontology term while 'values_from' is the identifier of an entire value set.  Additionally, this is different than an enumeration in that in an enumeration, the values of the enumeration are listed directly in the model itself. Setting this property on a slot does not guarantee an expansion of the ontological hiearchy into an enumerated list of possible values in every serialization of the model.",
@@ -1468,6 +1478,7 @@
          "description": "A rule that applies to instances of a class",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -1476,7 +1487,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -1651,13 +1663,14 @@
       },
       "EnumDefinition": {
          "additionalProperties": false,
-         "description": "List of values that constrain the range of a slot",
+         "description": "an element whose instances must be drawn from a specified set of permissible values",
          "properties": {
             "abstract": {
-               "description": "an abstract class is a high level class or slot that is typically used to group common slots together and cannot be directly instantiated.",
+               "description": "Indicates the class or slot cannot be directly instantiated and is intended for grouping and specifying core inherited metaslots",
                "type": "boolean"
             },
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -1666,7 +1679,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -1755,7 +1769,7 @@
                "type": "string"
             },
             "enum_uri": {
-               "description": "URI of the enum in an RDF environment",
+               "description": "URI of the enum that provides a semantic interpretation of the element in a linked data context. The URI may come from any namespace and may be shared between schemas",
                "type": "string"
             },
             "exact_mappings": {
@@ -1818,7 +1832,7 @@
                "type": "array"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent class or slot from which inheritable metaslots are propagated from. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
                "type": "string"
             },
             "last_updated_on": {
@@ -1850,11 +1864,11 @@
                "type": "array"
             },
             "mixin": {
-               "description": "this slot or class can only be used as a mixin.",
+               "description": "Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins.",
                "type": "boolean"
             },
             "mixins": {
-               "description": "List of definitions to be mixed in. Targets may be any definition of the same type",
+               "description": "A collection of secondary parent classes or slots from which inheritable metaslots are propagated from.",
                "items": {
                   "type": "string"
                },
@@ -1960,13 +1974,14 @@
       },
       "EnumDefinition__identifier_optional": {
          "additionalProperties": false,
-         "description": "List of values that constrain the range of a slot",
+         "description": "an element whose instances must be drawn from a specified set of permissible values",
          "properties": {
             "abstract": {
-               "description": "an abstract class is a high level class or slot that is typically used to group common slots together and cannot be directly instantiated.",
+               "description": "Indicates the class or slot cannot be directly instantiated and is intended for grouping and specifying core inherited metaslots",
                "type": "boolean"
             },
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -1975,7 +1990,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -2064,7 +2080,7 @@
                "type": "string"
             },
             "enum_uri": {
-               "description": "URI of the enum in an RDF environment",
+               "description": "URI of the enum that provides a semantic interpretation of the element in a linked data context. The URI may come from any namespace and may be shared between schemas",
                "type": "string"
             },
             "exact_mappings": {
@@ -2127,7 +2143,7 @@
                "type": "array"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent class or slot from which inheritable metaslots are propagated from. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
                "type": "string"
             },
             "last_updated_on": {
@@ -2159,11 +2175,11 @@
                "type": "array"
             },
             "mixin": {
-               "description": "this slot or class can only be used as a mixin.",
+               "description": "Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins.",
                "type": "boolean"
             },
             "mixins": {
-               "description": "List of definitions to be mixed in. Targets may be any definition of the same type",
+               "description": "A collection of secondary parent classes or slots from which inheritable metaslots are propagated from.",
                "items": {
                   "type": "string"
                },
@@ -2405,6 +2421,7 @@
          "description": "an expression describing an import",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -2413,7 +2430,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -2636,6 +2654,7 @@
          "description": "An expression that describes an abstract path from an object to another through a sequence of slot lookups",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -2651,7 +2670,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -2842,6 +2862,7 @@
          "description": "a regular expression pattern used to evaluate conformance of a string",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -2850,7 +2871,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -3016,6 +3038,7 @@
          "description": "a permissible value, accompanied by intended text and an optional mapping to a concept URI",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -3024,7 +3047,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -3108,7 +3132,7 @@
                "type": "array"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent class or slot from which inheritable metaslots are propagated from. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
                "type": "string"
             },
             "mappings": {
@@ -3123,7 +3147,7 @@
                "type": "string"
             },
             "mixins": {
-               "description": "List of definitions to be mixed in. Targets may be any definition of the same type",
+               "description": "A collection of secondary parent classes or slots from which inheritable metaslots are propagated from.",
                "items": {
                   "type": "string"
                },
@@ -3202,6 +3226,7 @@
          "description": "a permissible value, accompanied by intended text and an optional mapping to a concept URI",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -3210,7 +3235,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -3294,7 +3320,7 @@
                "type": "array"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent class or slot from which inheritable metaslots are propagated from. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
                "type": "string"
             },
             "mappings": {
@@ -3309,7 +3335,7 @@
                "type": "string"
             },
             "mixins": {
-               "description": "List of definitions to be mixed in. Targets may be any definition of the same type",
+               "description": "A collection of secondary parent classes or slots from which inheritable metaslots are propagated from.",
                "items": {
                   "type": "string"
                },
@@ -3497,6 +3523,7 @@
          "description": "a collection of subset, type, slot and class definitions",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -3505,7 +3532,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -3531,7 +3559,7 @@
                "additionalProperties": {
                   "$ref": "#/$defs/ClassDefinition__identifier_optional"
                },
-               "description": "class definitions"
+               "description": "An index to the collection of all class definitions in the schema"
             },
             "close_mappings": {
                "description": "A list of terms from different schemas or terminology systems that have close meaning.",
@@ -3597,7 +3625,7 @@
                "additionalProperties": {
                   "$ref": "#/$defs/EnumDefinition__identifier_optional"
                },
-               "description": "enumerated ranges"
+               "description": "An index to the collection of all enum definitions in the schema"
             },
             "exact_mappings": {
                "description": "A list of terms from different schemas or terminology systems that have identical meaning.",
@@ -3688,7 +3716,7 @@
                "type": "string"
             },
             "name": {
-               "description": "the unique name of the element within the context of the schema.  Name is combined with the default prefix to form the globally unique subject of the target class.",
+               "description": "a unique name for the schema that is both human-readable and consists of only characters from the NCName set",
                "type": "string"
             },
             "narrow_mappings": {
@@ -3743,7 +3771,7 @@
                "additionalProperties": {
                   "$ref": "#/$defs/SlotDefinition__identifier_optional"
                },
-               "description": "slot definitions"
+               "description": "An index to the collection of all slot definitions in the schema"
             },
             "source": {
                "description": "A related resource from which the element is derived.",
@@ -3773,7 +3801,7 @@
                "additionalProperties": {
                   "$ref": "#/$defs/SubsetDefinition__identifier_optional"
                },
-               "description": "list of subsets referenced in this model"
+               "description": "An index to the collection of all subset definitions in the schema"
             },
             "title": {
                "description": "the official title of the element",
@@ -3790,7 +3818,7 @@
                "additionalProperties": {
                   "$ref": "#/$defs/TypeDefinition__identifier_optional"
                },
-               "description": "data types used in the model"
+               "description": "An index to the collection of all type definitions in the schema"
             },
             "version": {
                "description": "particular version of schema",
@@ -3845,10 +3873,10 @@
       },
       "SlotDefinition": {
          "additionalProperties": false,
-         "description": "the definition of a property or a slot",
+         "description": "an element that describes how instances are related to other instances",
          "properties": {
             "abstract": {
-               "description": "an abstract class is a high level class or slot that is typically used to group common slots together and cannot be directly instantiated.",
+               "description": "Indicates the class or slot cannot be directly instantiated and is intended for grouping and specifying core inherited metaslots",
                "type": "boolean"
             },
             "alias": {
@@ -3856,16 +3884,15 @@
                "type": "string"
             },
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
                "type": "array"
             },
             "all_members": {
-               "additionalProperties": {
-                  "$ref": "#/$defs/SlotDefinition__identifier_optional"
-               },
-               "description": "the value of the multiavlued slot is a list where all elements conform to the specified values.\nthis defines a dynamic class with named slots according to matching constraints\n\nE.g to state that all members of a list are between 1 and 10\n```\nall_members:\n  x:\n    range: integer\n    minimum_value: 10\n    maximum_value: 10\n```"
+               "$ref": "#/$defs/AnonymousSlotExpression",
+               "description": "the value of the slot is multivalued with all members satisfying the condition"
             },
             "all_of": {
                "description": "holds if all of the expressions hold",
@@ -3877,7 +3904,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -4039,7 +4067,7 @@
             },
             "has_member": {
                "$ref": "#/$defs/AnonymousSlotExpression",
-               "description": "the values of the slot is multivalued with at least one member satisfying the condition"
+               "description": "the value of the slot is multivalued with at least one member satisfying the condition"
             },
             "id_prefixes": {
                "description": "the identifier of this class or slot must begin with the URIs referenced by this prefix",
@@ -4095,11 +4123,11 @@
                "type": "boolean"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent slot from which inheritable metaslots are propagated",
                "type": "string"
             },
             "is_class_field": {
-               "description": "indicates that any instance, i,  the domain of this slot will include an assert of i s range",
+               "description": "indicates that for any instance, i, the domain of this slot will include an assertion of i s range",
                "type": "boolean"
             },
             "is_grouping_slot": {
@@ -4133,7 +4161,7 @@
                }
             },
             "locally_reflexive": {
-               "description": "If s is locally_reflexive, then i.s=i for all instances i where s if a class slot for the type of i",
+               "description": "If s is locally_reflexive, then i.s=i for all instances i where s is a class slot for the type of i",
                "type": "boolean"
             },
             "mappings": {
@@ -4160,11 +4188,11 @@
                "type": "integer"
             },
             "mixin": {
-               "description": "this slot or class can only be used as a mixin.",
+               "description": "Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins.",
                "type": "boolean"
             },
             "mixins": {
-               "description": "List of definitions to be mixed in. Targets may be any definition of the same type",
+               "description": "A collection of secondary parent mixin slots from which inheritable metaslots are propagated",
                "items": {
                   "type": "string"
                },
@@ -4259,7 +4287,7 @@
                "type": "boolean"
             },
             "role": {
-               "description": "the role played by the slot range",
+               "description": "a textual descriptor that indicates the role played by the slot range",
                "type": "string"
             },
             "see_also": {
@@ -4349,6 +4377,10 @@
             "usage_slot_name": {
                "description": "The name of the slot referenced in the slot_usage",
                "type": "string"
+            },
+            "value_presence": {
+               "$ref": "#/$defs/PresenceEnum",
+               "description": "if true then a value must be present (for lists there must be at least one value). If false then a value must be absent (for lists, must be empty)"
             },
             "values_from": {
                "description": "The identifier of a \"value set\" -- a set of identifiers that form the possible values for the range of a slot. Note: this is different than 'subproperty_of' in that 'subproperty_of' is intended to be a single ontology term while 'values_from' is the identifier of an entire value set.  Additionally, this is different than an enumeration in that in an enumeration, the values of the enumeration are listed directly in the model itself. Setting this property on a slot does not guarantee an expansion of the ontological hiearchy into an enumerated list of possible values in every serialization of the model.",
@@ -4366,10 +4398,10 @@
       },
       "SlotDefinition__identifier_optional": {
          "additionalProperties": false,
-         "description": "the definition of a property or a slot",
+         "description": "an element that describes how instances are related to other instances",
          "properties": {
             "abstract": {
-               "description": "an abstract class is a high level class or slot that is typically used to group common slots together and cannot be directly instantiated.",
+               "description": "Indicates the class or slot cannot be directly instantiated and is intended for grouping and specifying core inherited metaslots",
                "type": "boolean"
             },
             "alias": {
@@ -4377,16 +4409,15 @@
                "type": "string"
             },
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
                "type": "array"
             },
             "all_members": {
-               "additionalProperties": {
-                  "$ref": "#/$defs/SlotDefinition__identifier_optional"
-               },
-               "description": "the value of the multiavlued slot is a list where all elements conform to the specified values.\nthis defines a dynamic class with named slots according to matching constraints\n\nE.g to state that all members of a list are between 1 and 10\n```\nall_members:\n  x:\n    range: integer\n    minimum_value: 10\n    maximum_value: 10\n```"
+               "$ref": "#/$defs/AnonymousSlotExpression",
+               "description": "the value of the slot is multivalued with all members satisfying the condition"
             },
             "all_of": {
                "description": "holds if all of the expressions hold",
@@ -4398,7 +4429,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -4560,7 +4592,7 @@
             },
             "has_member": {
                "$ref": "#/$defs/AnonymousSlotExpression",
-               "description": "the values of the slot is multivalued with at least one member satisfying the condition"
+               "description": "the value of the slot is multivalued with at least one member satisfying the condition"
             },
             "id_prefixes": {
                "description": "the identifier of this class or slot must begin with the URIs referenced by this prefix",
@@ -4616,11 +4648,11 @@
                "type": "boolean"
             },
             "is_a": {
-               "description": "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded",
+               "description": "A primary parent slot from which inheritable metaslots are propagated",
                "type": "string"
             },
             "is_class_field": {
-               "description": "indicates that any instance, i,  the domain of this slot will include an assert of i s range",
+               "description": "indicates that for any instance, i, the domain of this slot will include an assertion of i s range",
                "type": "boolean"
             },
             "is_grouping_slot": {
@@ -4654,7 +4686,7 @@
                }
             },
             "locally_reflexive": {
-               "description": "If s is locally_reflexive, then i.s=i for all instances i where s if a class slot for the type of i",
+               "description": "If s is locally_reflexive, then i.s=i for all instances i where s is a class slot for the type of i",
                "type": "boolean"
             },
             "mappings": {
@@ -4681,11 +4713,11 @@
                "type": "integer"
             },
             "mixin": {
-               "description": "this slot or class can only be used as a mixin.",
+               "description": "Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins.",
                "type": "boolean"
             },
             "mixins": {
-               "description": "List of definitions to be mixed in. Targets may be any definition of the same type",
+               "description": "A collection of secondary parent mixin slots from which inheritable metaslots are propagated",
                "items": {
                   "type": "string"
                },
@@ -4780,7 +4812,7 @@
                "type": "boolean"
             },
             "role": {
-               "description": "the role played by the slot range",
+               "description": "a textual descriptor that indicates the role played by the slot range",
                "type": "string"
             },
             "see_also": {
@@ -4870,6 +4902,10 @@
             "usage_slot_name": {
                "description": "The name of the slot referenced in the slot_usage",
                "type": "string"
+            },
+            "value_presence": {
+               "$ref": "#/$defs/PresenceEnum",
+               "description": "if true then a value must be present (for lists there must be at least one value). If false then a value must be absent (for lists, must be empty)"
             },
             "values_from": {
                "description": "The identifier of a \"value set\" -- a set of identifiers that form the possible values for the range of a slot. Note: this is different than 'subproperty_of' in that 'subproperty_of' is intended to be a single ontology term while 'values_from' is the identifier of an entire value set.  Additionally, this is different than an enumeration in that in an enumeration, the values of the enumeration are listed directly in the model itself. Setting this property on a slot does not guarantee an expansion of the ontological hiearchy into an enumerated list of possible values in every serialization of the model.",
@@ -4888,6 +4924,7 @@
          "description": "object that contains meta data about a synonym or alias including where it came from (source) and its scope (narrow, broad, etc.)",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -4896,7 +4933,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -5064,9 +5102,10 @@
       },
       "SubsetDefinition": {
          "additionalProperties": false,
-         "description": "the name and description of a subset",
+         "description": "an element that can be used to group other metamodel elements",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -5075,7 +5114,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -5252,9 +5292,10 @@
       },
       "SubsetDefinition__identifier_optional": {
          "additionalProperties": false,
-         "description": "the name and description of a subset",
+         "description": "an element that can be used to group other metamodel elements",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -5263,7 +5304,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -5438,9 +5480,10 @@
       },
       "TypeDefinition": {
          "additionalProperties": false,
-         "description": "A data type definition.",
+         "description": "an element that whose instances are atomic scalar values that can be mapped to primitive types",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -5456,7 +5499,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -5716,9 +5760,10 @@
       },
       "TypeDefinition__identifier_optional": {
          "additionalProperties": false,
-         "description": "A data type definition.",
+         "description": "an element that whose instances are atomic scalar values that can be mapped to primitive types",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -5734,7 +5779,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -5995,6 +6041,7 @@
          "description": "a collection of slots whose values uniquely identify an instance of a class",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -6003,7 +6050,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -6171,6 +6219,7 @@
          "description": "a collection of slots whose values uniquely identify an instance of a class",
          "properties": {
             "aliases": {
+               "description": "Alaternate names for the element",
                "items": {
                   "type": "string"
                },
@@ -6179,7 +6228,8 @@
             "alt_descriptions": {
                "additionalProperties": {
                   "$ref": "#/$defs/AltDescription__identifier_optional"
-               }
+               },
+               "description": "A sourced alternative description for an element"
             },
             "annotations": {
                "additionalProperties": {
@@ -6383,6 +6433,7 @@
    "metamodel_version": "1.7.0",
    "properties": {
       "aliases": {
+         "description": "Alaternate names for the element",
          "items": {
             "type": "string"
          },
@@ -6391,7 +6442,8 @@
       "alt_descriptions": {
          "additionalProperties": {
             "$ref": "#/$defs/AltDescription__identifier_optional"
-         }
+         },
+         "description": "A sourced alternative description for an element"
       },
       "annotations": {
          "additionalProperties": {
@@ -6417,7 +6469,7 @@
          "additionalProperties": {
             "$ref": "#/$defs/ClassDefinition__identifier_optional"
          },
-         "description": "class definitions"
+         "description": "An index to the collection of all class definitions in the schema"
       },
       "close_mappings": {
          "description": "A list of terms from different schemas or terminology systems that have close meaning.",
@@ -6483,7 +6535,7 @@
          "additionalProperties": {
             "$ref": "#/$defs/EnumDefinition__identifier_optional"
          },
-         "description": "enumerated ranges"
+         "description": "An index to the collection of all enum definitions in the schema"
       },
       "exact_mappings": {
          "description": "A list of terms from different schemas or terminology systems that have identical meaning.",
@@ -6574,7 +6626,7 @@
          "type": "string"
       },
       "name": {
-         "description": "the unique name of the element within the context of the schema.  Name is combined with the default prefix to form the globally unique subject of the target class.",
+         "description": "a unique name for the schema that is both human-readable and consists of only characters from the NCName set",
          "type": "string"
       },
       "narrow_mappings": {
@@ -6629,7 +6681,7 @@
          "additionalProperties": {
             "$ref": "#/$defs/SlotDefinition__identifier_optional"
          },
-         "description": "slot definitions"
+         "description": "An index to the collection of all slot definitions in the schema"
       },
       "source": {
          "description": "A related resource from which the element is derived.",
@@ -6659,7 +6711,7 @@
          "additionalProperties": {
             "$ref": "#/$defs/SubsetDefinition__identifier_optional"
          },
-         "description": "list of subsets referenced in this model"
+         "description": "An index to the collection of all subset definitions in the schema"
       },
       "title": {
          "description": "the official title of the element",
@@ -6676,7 +6728,7 @@
          "additionalProperties": {
             "$ref": "#/$defs/TypeDefinition__identifier_optional"
          },
-         "description": "data types used in the model"
+         "description": "An index to the collection of all type definitions in the schema"
       },
       "version": {
          "description": "particular version of schema",
@@ -6691,4 +6743,3 @@
    "type": "object",
    "version": "2.0.0"
 }
-

--- a/linkml_model/meta.py
+++ b/linkml_model/meta.py
@@ -1,18 +1,19 @@
 # Auto generated from meta.yaml by pythongen.py version: 0.9.0
-# Generation date: 2022-07-20T18:53:57
+# Generation date: 2022-12-09T14:57:09
 # Schema: meta
 #
 # id: https://w3id.org/linkml/meta
 # description: The metamodel for schemas defined using the Linked Data Modeling Language framework. For more
 #              information on LinkML: * [linkml.io](https://linkml.io) main website *
-#              [specification](https://linkml.io/linkml-model/docs/specification/) Core metaclasses: *
-#              [SchemaDefinition](https://w3id.org/linkml/SchemaDefinition) *
+#              [specification](https://linkml.io/linkml-model/docs/specification/) LinkML is self-describing.
+#              Every LinkML schema consists of elements that instantiate classes in this metamodel. Core
+#              metaclasses: * [SchemaDefinition](https://w3id.org/linkml/SchemaDefinition) *
 #              [ClassDefinition](https://w3id.org/linkml/ClassDefinition) *
 #              [SlotDefinition](https://w3id.org/linkml/SlotDefinition) *
-#              [TypeDefinition](https://w3id.org/linkml/TypeDefinition) Every LinkML model instantiates
-#              SchemaDefinition, all classes in the model instantiate ClassDefinition, and so on Note that the
-#              LinkML metamodel instantiates itself. For a non-normative introduction to LinkML schemas, see the
-#              tutorial and schema guide on [linkml.io/linkml]. For canonical reference documentation on any
+#              [TypeDefinition](https://w3id.org/linkml/TypeDefinition) There are many subsets of *profiles* of
+#              the metamodel, for different purposes: * [MinimalSubset](https://w3id.org/linkml/MinimalSubset) *
+#              [BasicSubset](https://w3id.org/linkml/BasicSubset) *
+#              [BasicSubset](https://w3id.org/linkml/BasicSubset) For canonical reference documentation on any
 #              metamodel construct, refer to the official URI for each construct, e.g.
 #              [https://w3id.org/linkml/is_a](https://w3id.org/linkml/is_a)
 # license: https://creativecommons.org/publicdomain/zero/1.0/
@@ -23,7 +24,6 @@ import re
 from jsonasobj2 import JsonObj, as_dict
 from typing import Optional, List, Union, Dict, ClassVar, Any
 from dataclasses import dataclass
-from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
 
 from linkml_runtime.utils.slot import Slot
 from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
@@ -33,10 +33,10 @@ from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
 from rdflib import Namespace, URIRef
 from linkml_runtime.utils.curienamespace import CurieNamespace
-from linkml_runtime.linkml_model.annotations import Annotation, AnnotationTag
-from linkml_runtime.linkml_model.extensions import Extension, ExtensionTag
-from linkml_runtime.linkml_model.types import Boolean, Datetime, Integer, Ncname, String, Uri, Uriorcurie
-from linkml_runtime.linkml_model.units import UnitOfMeasure
+from .annotations import Annotation, AnnotationTag
+from .extensions import Extension, ExtensionTag
+from .types import Boolean, Datetime, Integer, Ncname, String, Uri, Uriorcurie
+from .units import UnitOfMeasure
 from linkml_runtime.utils.metamodelcore import Bool, NCName, URI, URIorCURIE, XSDDateTime
 
 metamodel_version = "1.7.0"
@@ -46,7 +46,6 @@ version = "2.0.0"
 dataclasses._init_fn = dataclasses_init_fn_with_kwargs
 
 # Namespaces
-IAO = CurieNamespace('IAO', 'http://purl.obolibrary.org/obo/IAO_')
 NCIT = CurieNamespace('NCIT', 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#')
 OIO = CurieNamespace('OIO', 'http://www.geneontology.org/formats/oboInOwl#')
 BIBO = CurieNamespace('bibo', 'http://purl.org/ontology/bibo/')
@@ -1605,7 +1604,7 @@ class SlotExpression(Expression):
     """
     an expression that constrains the range of values a slot can take
     """
-    _inherited_slots: ClassVar[List[str]] = ["range", "required", "recommended", "inlined", "inlined_as_list", "minimum_value", "maximum_value", "pattern", "structured_pattern", "equals_string", "equals_string_in", "equals_number", "equals_expression", "minimum_cardinality", "maximum_cardinality"]
+    _inherited_slots: ClassVar[List[str]] = ["range", "required", "recommended", "inlined", "inlined_as_list", "minimum_value", "maximum_value", "pattern", "structured_pattern", "value_presence", "equals_string", "equals_string_in", "equals_number", "equals_expression", "minimum_cardinality", "maximum_cardinality"]
 
     class_class_uri: ClassVar[URIRef] = LINKML.SlotExpression
     class_class_curie: ClassVar[str] = "linkml:SlotExpression"
@@ -1625,6 +1624,7 @@ class SlotExpression(Expression):
     structured_pattern: Optional[Union[dict, "PatternExpression"]] = None
     unit: Optional[Union[dict, UnitOfMeasure]] = None
     implicit_prefix: Optional[str] = None
+    value_presence: Optional[Union[str, "PresenceEnum"]] = None
     equals_string: Optional[str] = None
     equals_string_in: Optional[Union[str, List[str]]] = empty_list()
     equals_number: Optional[int] = None
@@ -1632,7 +1632,7 @@ class SlotExpression(Expression):
     minimum_cardinality: Optional[int] = None
     maximum_cardinality: Optional[int] = None
     has_member: Optional[Union[dict, "AnonymousSlotExpression"]] = None
-    all_members: Optional[Union[Dict[Union[str, SlotDefinitionName], Union[dict, "SlotDefinition"]], List[Union[dict, "SlotDefinition"]]]] = empty_dict()
+    all_members: Optional[Union[dict, "AnonymousSlotExpression"]] = None
     none_of: Optional[Union[Union[dict, "AnonymousSlotExpression"], List[Union[dict, "AnonymousSlotExpression"]]]] = empty_list()
     exactly_one_of: Optional[Union[Union[dict, "AnonymousSlotExpression"], List[Union[dict, "AnonymousSlotExpression"]]]] = empty_list()
     any_of: Optional[Union[Union[dict, "AnonymousSlotExpression"], List[Union[dict, "AnonymousSlotExpression"]]]] = empty_list()
@@ -1678,6 +1678,9 @@ class SlotExpression(Expression):
         if self.implicit_prefix is not None and not isinstance(self.implicit_prefix, str):
             self.implicit_prefix = str(self.implicit_prefix)
 
+        if self.value_presence is not None and not isinstance(self.value_presence, PresenceEnum):
+            self.value_presence = PresenceEnum(self.value_presence)
+
         if self.equals_string is not None and not isinstance(self.equals_string, str):
             self.equals_string = str(self.equals_string)
 
@@ -1700,7 +1703,8 @@ class SlotExpression(Expression):
         if self.has_member is not None and not isinstance(self.has_member, AnonymousSlotExpression):
             self.has_member = AnonymousSlotExpression(**as_dict(self.has_member))
 
-        self._normalize_inlined_as_dict(slot_name="all_members", slot_type=SlotDefinition, key_name="name", keyed=True)
+        if self.all_members is not None and not isinstance(self.all_members, AnonymousSlotExpression):
+            self.all_members = AnonymousSlotExpression(**as_dict(self.all_members))
 
         if not isinstance(self.none_of, list):
             self.none_of = [self.none_of] if self.none_of is not None else []
@@ -1723,7 +1727,7 @@ class SlotExpression(Expression):
 
 @dataclass
 class AnonymousSlotExpression(AnonymousExpression):
-    _inherited_slots: ClassVar[List[str]] = ["range", "required", "recommended", "inlined", "inlined_as_list", "minimum_value", "maximum_value", "pattern", "structured_pattern", "equals_string", "equals_string_in", "equals_number", "equals_expression", "minimum_cardinality", "maximum_cardinality"]
+    _inherited_slots: ClassVar[List[str]] = ["range", "required", "recommended", "inlined", "inlined_as_list", "minimum_value", "maximum_value", "pattern", "structured_pattern", "value_presence", "equals_string", "equals_string_in", "equals_number", "equals_expression", "minimum_cardinality", "maximum_cardinality"]
 
     class_class_uri: ClassVar[URIRef] = LINKML.AnonymousSlotExpression
     class_class_curie: ClassVar[str] = "linkml:AnonymousSlotExpression"
@@ -1743,6 +1747,7 @@ class AnonymousSlotExpression(AnonymousExpression):
     structured_pattern: Optional[Union[dict, "PatternExpression"]] = None
     unit: Optional[Union[dict, UnitOfMeasure]] = None
     implicit_prefix: Optional[str] = None
+    value_presence: Optional[Union[str, "PresenceEnum"]] = None
     equals_string: Optional[str] = None
     equals_string_in: Optional[Union[str, List[str]]] = empty_list()
     equals_number: Optional[int] = None
@@ -1750,7 +1755,7 @@ class AnonymousSlotExpression(AnonymousExpression):
     minimum_cardinality: Optional[int] = None
     maximum_cardinality: Optional[int] = None
     has_member: Optional[Union[dict, "AnonymousSlotExpression"]] = None
-    all_members: Optional[Union[Dict[Union[str, SlotDefinitionName], Union[dict, "SlotDefinition"]], List[Union[dict, "SlotDefinition"]]]] = empty_dict()
+    all_members: Optional[Union[dict, "AnonymousSlotExpression"]] = None
     none_of: Optional[Union[Union[dict, "AnonymousSlotExpression"], List[Union[dict, "AnonymousSlotExpression"]]]] = empty_list()
     exactly_one_of: Optional[Union[Union[dict, "AnonymousSlotExpression"], List[Union[dict, "AnonymousSlotExpression"]]]] = empty_list()
     any_of: Optional[Union[Union[dict, "AnonymousSlotExpression"], List[Union[dict, "AnonymousSlotExpression"]]]] = empty_list()
@@ -1796,6 +1801,9 @@ class AnonymousSlotExpression(AnonymousExpression):
         if self.implicit_prefix is not None and not isinstance(self.implicit_prefix, str):
             self.implicit_prefix = str(self.implicit_prefix)
 
+        if self.value_presence is not None and not isinstance(self.value_presence, PresenceEnum):
+            self.value_presence = PresenceEnum(self.value_presence)
+
         if self.equals_string is not None and not isinstance(self.equals_string, str):
             self.equals_string = str(self.equals_string)
 
@@ -1818,7 +1826,8 @@ class AnonymousSlotExpression(AnonymousExpression):
         if self.has_member is not None and not isinstance(self.has_member, AnonymousSlotExpression):
             self.has_member = AnonymousSlotExpression(**as_dict(self.has_member))
 
-        self._normalize_inlined_as_dict(slot_name="all_members", slot_type=SlotDefinition, key_name="name", keyed=True)
+        if self.all_members is not None and not isinstance(self.all_members, AnonymousSlotExpression):
+            self.all_members = AnonymousSlotExpression(**as_dict(self.all_members))
 
         if not isinstance(self.none_of, list):
             self.none_of = [self.none_of] if self.none_of is not None else []
@@ -1844,7 +1853,7 @@ class SlotDefinition(Definition):
     """
     an element that describes how instances are related to other instances
     """
-    _inherited_slots: ClassVar[List[str]] = ["domain", "multivalued", "inherited", "readonly", "ifabsent", "list_elements_unique", "list_elements_ordered", "shared", "key", "identifier", "designates_type", "role", "relational_role", "range", "required", "recommended", "inlined", "inlined_as_list", "minimum_value", "maximum_value", "pattern", "structured_pattern", "equals_string", "equals_string_in", "equals_number", "equals_expression", "minimum_cardinality", "maximum_cardinality"]
+    _inherited_slots: ClassVar[List[str]] = ["domain", "multivalued", "inherited", "readonly", "ifabsent", "list_elements_unique", "list_elements_ordered", "shared", "key", "identifier", "designates_type", "role", "relational_role", "range", "required", "recommended", "inlined", "inlined_as_list", "minimum_value", "maximum_value", "pattern", "structured_pattern", "value_presence", "equals_string", "equals_string_in", "equals_number", "equals_expression", "minimum_cardinality", "maximum_cardinality"]
 
     class_class_uri: ClassVar[URIRef] = LINKML.SlotDefinition
     class_class_curie: ClassVar[str] = "linkml:SlotDefinition"
@@ -1888,7 +1897,7 @@ class SlotDefinition(Definition):
     path_rule: Optional[Union[dict, PathExpression]] = None
     disjoint_with: Optional[Union[Union[str, SlotDefinitionName], List[Union[str, SlotDefinitionName]]]] = empty_list()
     children_are_mutually_disjoint: Optional[Union[bool, Bool]] = None
-    union_of: Optional[Union[Union[str, TypeDefinitionName], List[Union[str, TypeDefinitionName]]]] = empty_list()
+    union_of: Optional[Union[Union[str, SlotDefinitionName], List[Union[str, SlotDefinitionName]]]] = empty_list()
     is_a: Optional[Union[str, SlotDefinitionName]] = None
     mixins: Optional[Union[Union[str, SlotDefinitionName], List[Union[str, SlotDefinitionName]]]] = empty_list()
     apply_to: Optional[Union[Union[str, SlotDefinitionName], List[Union[str, SlotDefinitionName]]]] = empty_list()
@@ -1905,6 +1914,7 @@ class SlotDefinition(Definition):
     structured_pattern: Optional[Union[dict, "PatternExpression"]] = None
     unit: Optional[Union[dict, UnitOfMeasure]] = None
     implicit_prefix: Optional[str] = None
+    value_presence: Optional[Union[str, "PresenceEnum"]] = None
     equals_string: Optional[str] = None
     equals_string_in: Optional[Union[str, List[str]]] = empty_list()
     equals_number: Optional[int] = None
@@ -1912,7 +1922,7 @@ class SlotDefinition(Definition):
     minimum_cardinality: Optional[int] = None
     maximum_cardinality: Optional[int] = None
     has_member: Optional[Union[dict, AnonymousSlotExpression]] = None
-    all_members: Optional[Union[Dict[Union[str, SlotDefinitionName], Union[dict, "SlotDefinition"]], List[Union[dict, "SlotDefinition"]]]] = empty_dict()
+    all_members: Optional[Union[dict, AnonymousSlotExpression]] = None
     none_of: Optional[Union[Union[dict, AnonymousSlotExpression], List[Union[dict, AnonymousSlotExpression]]]] = empty_list()
     exactly_one_of: Optional[Union[Union[dict, AnonymousSlotExpression], List[Union[dict, AnonymousSlotExpression]]]] = empty_list()
     any_of: Optional[Union[Union[dict, AnonymousSlotExpression], List[Union[dict, AnonymousSlotExpression]]]] = empty_list()
@@ -2036,7 +2046,7 @@ class SlotDefinition(Definition):
 
         if not isinstance(self.union_of, list):
             self.union_of = [self.union_of] if self.union_of is not None else []
-        self.union_of = [v if isinstance(v, TypeDefinitionName) else TypeDefinitionName(v) for v in self.union_of]
+        self.union_of = [v if isinstance(v, SlotDefinitionName) else SlotDefinitionName(v) for v in self.union_of]
 
         if self.is_a is not None and not isinstance(self.is_a, SlotDefinitionName):
             self.is_a = SlotDefinitionName(self.is_a)
@@ -2088,6 +2098,9 @@ class SlotDefinition(Definition):
         if self.implicit_prefix is not None and not isinstance(self.implicit_prefix, str):
             self.implicit_prefix = str(self.implicit_prefix)
 
+        if self.value_presence is not None and not isinstance(self.value_presence, PresenceEnum):
+            self.value_presence = PresenceEnum(self.value_presence)
+
         if self.equals_string is not None and not isinstance(self.equals_string, str):
             self.equals_string = str(self.equals_string)
 
@@ -2110,7 +2123,8 @@ class SlotDefinition(Definition):
         if self.has_member is not None and not isinstance(self.has_member, AnonymousSlotExpression):
             self.has_member = AnonymousSlotExpression(**as_dict(self.has_member))
 
-        self._normalize_inlined_as_dict(slot_name="all_members", slot_type=SlotDefinition, key_name="name", keyed=True)
+        if self.all_members is not None and not isinstance(self.all_members, AnonymousSlotExpression):
+            self.all_members = AnonymousSlotExpression(**as_dict(self.all_members))
 
         if not isinstance(self.none_of, list):
             self.none_of = [self.none_of] if self.none_of is not None else []
@@ -3401,6 +3415,9 @@ slots.in_language = Slot(uri=SCHEMA.inLanguage, name="in_language", curie=SCHEMA
 slots.source = Slot(uri=DCTERMS.source, name="source", curie=DCTERMS.curie('source'),
                    model_uri=LINKML.source, domain=Element, range=Optional[Union[str, URIorCURIE]])
 
+slots.publisher = Slot(uri=DCTERMS.publisher, name="publisher", curie=DCTERMS.curie('publisher'),
+                   model_uri=LINKML.publisher, domain=Element, range=Optional[Union[str, URIorCURIE]])
+
 slots.is_a = Slot(uri=LINKML.is_a, name="is_a", curie=LINKML.curie('is_a'),
                    model_uri=LINKML.is_a, domain=Definition, range=Optional[Union[str, DefinitionName]])
 
@@ -3684,7 +3701,7 @@ slots.has_member = Slot(uri=LINKML.has_member, name="has_member", curie=LINKML.c
                    model_uri=LINKML.has_member, domain=None, range=Optional[Union[dict, AnonymousSlotExpression]])
 
 slots.all_members = Slot(uri=LINKML.all_members, name="all_members", curie=LINKML.curie('all_members'),
-                   model_uri=LINKML.all_members, domain=None, range=Optional[Union[Dict[Union[str, SlotDefinitionName], Union[dict, SlotDefinition]], List[Union[dict, SlotDefinition]]]])
+                   model_uri=LINKML.all_members, domain=None, range=Optional[Union[dict, AnonymousSlotExpression]])
 
 slots.singular_name = Slot(uri=SKOS.altLabel, name="singular_name", curie=SKOS.curie('altLabel'),
                    model_uri=LINKML.singular_name, domain=SlotDefinition, range=Optional[str])
@@ -3836,13 +3853,13 @@ slots.value_description = Slot(uri=LINKML.description, name="value_description",
 slots.examples = Slot(uri=LINKML.examples, name="examples", curie=LINKML.curie('examples'),
                    model_uri=LINKML.examples, domain=Element, range=Optional[Union[Union[dict, "Example"], List[Union[dict, "Example"]]]])
 
-slots.prefix_prefix = Slot(uri=LINKML.prefix_prefix, name="prefix_prefix", curie=LINKML.curie('prefix_prefix'),
+slots.prefix_prefix = Slot(uri=SH.prefix, name="prefix_prefix", curie=SH.curie('prefix'),
                    model_uri=LINKML.prefix_prefix, domain=Prefix, range=Union[str, PrefixPrefixPrefix])
 
-slots.prefix_reference = Slot(uri=LINKML.prefix_reference, name="prefix_reference", curie=LINKML.curie('prefix_reference'),
+slots.prefix_reference = Slot(uri=SH.namespace, name="prefix_reference", curie=SH.curie('namespace'),
                    model_uri=LINKML.prefix_reference, domain=Prefix, range=Union[str, URI])
 
-slots.prefixes = Slot(uri=LINKML.prefixes, name="prefixes", curie=LINKML.curie('prefixes'),
+slots.prefixes = Slot(uri=SH.declare, name="prefixes", curie=SH.curie('declare'),
                    model_uri=LINKML.prefixes, domain=SchemaDefinition, range=Optional[Union[Dict[Union[str, PrefixPrefixPrefix], Union[dict, "Prefix"]], List[Union[dict, "Prefix"]]]])
 
 slots.setting_key = Slot(uri=LINKML.setting_key, name="setting_key", curie=LINKML.curie('setting_key'),
@@ -3957,7 +3974,7 @@ slots.slot_definition_disjoint_with = Slot(uri=LINKML.disjoint_with, name="slot_
                    model_uri=LINKML.slot_definition_disjoint_with, domain=SlotDefinition, range=Optional[Union[Union[str, SlotDefinitionName], List[Union[str, SlotDefinitionName]]]])
 
 slots.slot_definition_union_of = Slot(uri=LINKML.union_of, name="slot_definition_union_of", curie=LINKML.curie('union_of'),
-                   model_uri=LINKML.slot_definition_union_of, domain=SlotDefinition, range=Optional[Union[Union[str, TypeDefinitionName], List[Union[str, TypeDefinitionName]]]])
+                   model_uri=LINKML.slot_definition_union_of, domain=SlotDefinition, range=Optional[Union[Union[str, SlotDefinitionName], List[Union[str, SlotDefinitionName]]]])
 
 slots.class_expression_any_of = Slot(uri=LINKML.any_of, name="class_expression_any_of", curie=LINKML.curie('any_of'),
                    model_uri=LINKML.class_expression_any_of, domain=None, range=Optional[Union[Union[dict, "AnonymousClassExpression"], List[Union[dict, "AnonymousClassExpression"]]]])

--- a/linkml_model/owl/meta.owl.ttl
+++ b/linkml_model/owl/meta.owl.ttl
@@ -1,4 +1,5 @@
 @prefix IAO: <http://purl.obolibrary.org/obo/IAO_> .
+@prefix NCIT: <http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#> .
 @prefix OIO: <http://www.geneontology.org/formats/oboInOwl#> .
 @prefix bibo: <http://purl.org/ontology/bibo/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -8,14 +9,15 @@
 @prefix pav: <http://purl.org/pav/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix schema1: <http://schema.org/> .
-@prefix sh1: <https://w3id.org/shacl/> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <https://w3id.org/shacl/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix swrl: <http://www.w3.org/2003/11/swrl#> .
-@prefix vann1: <https://vocab.org/vann/> .
+@prefix vann: <https://vocab.org/vann/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 linkml:equals_number_in a owl:ObjectProperty,
@@ -45,16 +47,19 @@ linkml:meta a owl:Ontology ;
         linkml:Extensible,
         linkml:Extension,
         linkml:LocalName,
+        linkml:MatchQuery,
         linkml:Prefix,
-        linkml:Setting ;
+        linkml:ReachabilityQuery,
+        linkml:Setting,
+        linkml:UnitOfMeasure ;
     dcterms:license "https://creativecommons.org/publicdomain/zero/1.0/" ;
     dcterms:title "LinkML Schema Metamodel" ;
     pav:version "2.0.0" ;
-    linkml:generation_date "2022-05-19T21:52:59" ;
+    linkml:generation_date "2022-12-09T14:57:01" ;
     linkml:metamodel_version "1.7.0" ;
     linkml:source_file "meta.yaml" ;
-    linkml:source_file_date "2022-05-19T21:50:21" ;
-    linkml:source_file_size 65393 .
+    linkml:source_file_date "2022-12-09T14:24:35" ;
+    linkml:source_file_size 81549 .
 
 linkml:owned_by a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -76,27 +81,26 @@ linkml:structured_imports a owl:ObjectProperty,
 linkml:topValue a owl:DatatypeProperty ;
     rdfs:label "value" .
 
-linkml:value_presence a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "value_presence" ;
-    rdfs:domain linkml:SlotDefinition ;
-    rdfs:range linkml:PresenceEnum ;
-    rdfs:subPropertyOf linkml:list_value_specification_constant ;
-    skos:definition "if true then a value must be present (for lists there must be at least one value). If false then a value must be absent (for lists, must be empty)" ;
-    skos:note "if set to true this has the same effect as required=true. In contrast, required=false allows a value to be present" .
-
 linkml:value_specification_constant a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "value_specification_constant" ;
     rdfs:range linkml:String ;
     skos:definition "Grouping for metamodel slots that constrain the a slot value to equal a specified constant" .
 
+dcterms:publisher a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "publisher" ;
+    rdfs:domain linkml:Element ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:definition "An entity responsible for making the resource available" ;
+    skos:exactMatch dcterms:publisher .
+
 linkml:abstract a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "abstract" ;
     rdfs:domain linkml:Definition ;
     rdfs:range linkml:Boolean ;
-    skos:definition "an abstract class is a high level class or slot that is typically used to group common slots together and cannot be directly instantiated." .
+    skos:definition "Indicates the class or slot cannot be directly instantiated and is intended for grouping and specifying core inherited metaslots" .
 
 linkml:asymmetric a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -139,14 +143,14 @@ linkml:class_uri a owl:ObjectProperty,
     rdfs:domain linkml:ClassDefinition ;
     rdfs:range linkml:Uriorcurie ;
     skos:altLabel "public ID" ;
-    skos:definition "URI of the class in an RDF environment" .
+    skos:definition "URI of the class that provides a semantic interpretation of the element in a linked data context. The URI may come from any namespace and may be shared between schemas" .
 
 linkml:classes a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "classes" ;
     rdfs:domain linkml:SchemaDefinition ;
     rdfs:range linkml:ClassDefinition ;
-    skos:definition "class definitions" .
+    skos:definition "An index to the collection of all class definitions in the schema" .
 
 linkml:classification_rules a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -154,29 +158,6 @@ linkml:classification_rules a owl:ObjectProperty,
     rdfs:domain linkml:ClassDefinition ;
     rdfs:range linkml:AnonymousClassExpression ;
     skos:definition "the collection of classification rules that apply to all members of this class" .
-
-linkml:code_set a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "code_set" ;
-    rdfs:domain linkml:EnumDefinition ;
-    rdfs:range linkml:Uriorcurie ;
-    skos:definition "the identifier of an enumeration code set." .
-
-linkml:code_set_tag a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "code_set_tag" ;
-    rdfs:domain linkml:EnumDefinition ;
-    rdfs:range linkml:String ;
-    skos:definition "the version tag of the enumeration code set" ;
-    skos:note "enum_definition cannot have both a code_set_tag and a code_set_version" .
-
-linkml:code_set_version a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "code_set_version" ;
-    rdfs:domain linkml:EnumDefinition ;
-    rdfs:range linkml:String ;
-    skos:definition "the version identifier of the enumeration code set" ;
-    skos:note "we assume that version identifiers lexically sort in temporal order. Recommend semver when possible" .
 
 linkml:default_curi_maps a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -214,6 +195,12 @@ linkml:definition_uri a owl:ObjectProperty,
     rdfs:range linkml:Uriorcurie ;
     skos:definition "the \"native\" URI of the element" ;
     skos:note "Formed by combining the default_prefix with the mangled element" .
+
+linkml:derivation a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "derivation" ;
+    rdfs:range linkml:String ;
+    skos:definition "Expression for deriving this unit from other units" .
 
 linkml:designates_type a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -260,12 +247,20 @@ linkml:emit_prefixes a owl:ObjectProperty,
     rdfs:range linkml:Ncname ;
     skos:definition "a list of Curie prefixes that are used in the representation of instances of the model.  All prefixes in this list are added to the prefix sections of the target models." .
 
+linkml:enum_uri a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "enum_uri" ;
+    rdfs:domain linkml:EnumDefinition ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:altLabel "public ID" ;
+    skos:definition "URI of the enum that provides a semantic interpretation of the element in a linked data context. The URI may come from any namespace and may be shared between schemas" .
+
 linkml:enums a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "enums" ;
     rdfs:domain linkml:SchemaDefinition ;
     rdfs:range linkml:EnumDefinition ;
-    skos:definition "enumerated ranges" .
+    skos:definition "An index to the collection of all enum definitions in the schema" .
 
 linkml:followed_by a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -315,12 +310,19 @@ linkml:identifier a owl:ObjectProperty,
         "identifier is inherited",
         "identifiers and keys are mutually exclusive.  A given domain cannot have both" .
 
+linkml:identifier_pattern a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "identifier_pattern" ;
+    rdfs:domain linkml:MatchQuery ;
+    rdfs:range linkml:String ;
+    skos:definition "A regular expression that is used to obtain a set of identifiers from a source_ontology to construct a set of permissible values" .
+
 linkml:ifabsent a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "ifabsent" ;
     rdfs:domain linkml:SlotDefinition ;
     rdfs:range linkml:String ;
-    skos:closeMatch sh1:defaultValue ;
+    skos:closeMatch sh:defaultValue ;
     skos:definition """function that provides a default value for the slot.  Possible values for this slot are defined in
 linkml_runtime.utils.ifabsent_functions.default_library:
   * [Tt]rue -- boolean True
@@ -358,6 +360,14 @@ linkml:imports a owl:ObjectProperty,
     rdfs:range linkml:Uriorcurie ;
     skos:definition "other schemas that are included in this schema" .
 
+linkml:include_self a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "include_self" ;
+    rdfs:domain linkml:ReachabilityQuery ;
+    rdfs:range linkml:Boolean ;
+    skos:altLabel "reflexive" ;
+    skos:definition "True if the query is reflexive" .
+
 linkml:inherited a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "inherited" ;
@@ -387,14 +397,22 @@ linkml:is_class_field a owl:ObjectProperty,
     rdfs:label "is_class_field" ;
     rdfs:domain linkml:SlotDefinition ;
     rdfs:range linkml:Boolean ;
-    skos:definition "indicates that any instance, i,  the domain of this slot will include an assert of i s range" .
+    skos:definition "indicates that for any instance, i, the domain of this slot will include an assertion of i s range" .
+
+linkml:is_direct a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "is_direct" ;
+    rdfs:domain linkml:ReachabilityQuery ;
+    rdfs:range linkml:Boolean ;
+    skos:altLabel "non-transitive" ;
+    skos:definition "True if the reachability query should only include directly related nodes, if False then include also transitively connected" .
 
 linkml:is_grouping_slot a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "is_grouping_slot" ;
     rdfs:domain linkml:SlotDefinition ;
     rdfs:range linkml:Boolean ;
-    skos:closeMatch sh1:PropertyGroup ;
+    skos:closeMatch sh:PropertyGroup ;
     skos:definition "true if this slot is a grouping slot" .
 
 linkml:is_usage_slot a owl:ObjectProperty,
@@ -451,7 +469,7 @@ linkml:locally_reflexive a owl:ObjectProperty,
     rdfs:domain linkml:SlotDefinition ;
     rdfs:range linkml:Boolean ;
     rdfs:subPropertyOf linkml:relational_logical_characteristic ;
-    skos:definition "If s is locally_reflexive, then i.s=i for all instances i where s if a class slot for the type of i" .
+    skos:definition "If s is locally_reflexive, then i.s=i for all instances i where s is a class slot for the type of i" .
 
 linkml:meaning a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -504,13 +522,6 @@ linkml:path_rule a owl:ObjectProperty,
     rdfs:range linkml:PathExpression ;
     skos:definition "a rule for inferring a slot assignment based on evaluating a path through a sequence of slot assignemnts" .
 
-linkml:permissible_values a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "permissible_values" ;
-    rdfs:domain linkml:EnumDefinition ;
-    rdfs:range linkml:PermissibleValue ;
-    skos:definition "A list of possible values for a slot range" .
-
 linkml:postconditions a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "postconditions" ;
@@ -520,36 +531,6 @@ linkml:postconditions a owl:ObjectProperty,
         "then" ;
     skos:closeMatch swrl:body ;
     skos:definition "an expression that must hold for an instance of the class, if the preconditions hold" .
-
-linkml:prefix_prefix a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "prefix_prefix" ;
-    rdfs:domain linkml:Prefix ;
-    rdfs:range linkml:Ncname ;
-    skos:definition "the nsname (sans ':' for a given prefix)" .
-
-linkml:prefix_reference a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "prefix_reference" ;
-    rdfs:domain linkml:Prefix ;
-    rdfs:range linkml:Uri ;
-    skos:definition "A URI associated with a given prefix" .
-
-linkml:prefixes a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "prefixes" ;
-    rdfs:domain linkml:SchemaDefinition ;
-    rdfs:range linkml:Prefix ;
-    skos:definition "prefix / URI definitions to be added to the context beyond those fetched from prefixcommons in id prefixes" .
-
-linkml:pv_formula a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "pv_formula" ;
-    rdfs:domain linkml:EnumDefinition ;
-    rdfs:range linkml:PvFormulaOptions ;
-    skos:definition "Defines the specific formula to be used to generate the permissible values." ;
-    skos:note "code_set must be supplied for this to be valid",
-        "you cannot have BOTH the permissible_values and permissible_value_formula tag" .
 
 linkml:readonly a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -586,6 +567,15 @@ linkml:relational_role a owl:ObjectProperty,
         "in the context of property graphs, this should be used on edge classes to indicate which slots represent the input and output nodes",
         "this should only be used on slots that are applicable to class that represent relationships" .
 
+linkml:relationship_types a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "relationship_types" ;
+    rdfs:domain linkml:ReachabilityQuery ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:altLabel "predicates",
+        "properties" ;
+    skos:definition "A list of relationship types (properties) that are used in a reachability query" .
+
 linkml:repr a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "repr" ;
@@ -617,7 +607,8 @@ linkml:role a owl:ObjectProperty,
     rdfs:label "role" ;
     rdfs:domain linkml:SlotDefinition ;
     rdfs:range linkml:String ;
-    skos:definition "the role played by the slot range" .
+    skos:definition "a textual descriptor that indicates the role played by the slot range" ;
+    skos:note "the primary use case for this slot is to provide a textual descriptor of a generic slot name when used in the context of a more specific class" .
 
 linkml:setting_key a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -663,7 +654,7 @@ linkml:slot_usage a owl:ObjectProperty,
     rdfs:label "slot_usage" ;
     rdfs:domain linkml:ClassDefinition ;
     rdfs:range linkml:SlotDefinition ;
-    skos:definition "the redefinition of a slot in the context of the containing class definition." ;
+    skos:definition "the refinement of a slot in the context of the containing class definition." ;
     skos:note "Many slots may be re-used across different classes, but the meaning of the slot may be refined by context. For example, a generic association model may use slots subject/predicate/object with generic semantics and minimal constraints. When this is subclasses, e.g. to disease-phenotype associations then slot usage may specify both local naming (e.g. subject=disease) and local constraints" .
 
 linkml:source_file a owl:ObjectProperty,
@@ -687,6 +678,13 @@ linkml:source_file_size a owl:ObjectProperty,
     rdfs:range linkml:Integer ;
     skos:definition "size in bytes of the source of the schema" .
 
+linkml:source_nodes a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "source_nodes" ;
+    rdfs:domain linkml:ReachabilityQuery ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:definition "A list of nodes that are used in the reachability query" .
+
 linkml:string_serialization a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "string_serialization" ;
@@ -703,7 +701,7 @@ linkml:subsets a owl:ObjectProperty,
     rdfs:label "subsets" ;
     rdfs:domain linkml:SchemaDefinition ;
     rdfs:range linkml:SubsetDefinition ;
-    skos:definition "list of subsets referenced in this model" ;
+    skos:definition "An index to the collection of all subset definitions in the schema" ;
     skos:exactMatch OIO:hasSubset .
 
 linkml:symmetric a owl:ObjectProperty,
@@ -734,7 +732,8 @@ linkml:text a owl:ObjectProperty,
     rdfs:label "text" ;
     rdfs:domain linkml:PermissibleValue ;
     rdfs:range linkml:String ;
-    skos:altLabel "value" .
+    skos:altLabel "value" ;
+    skos:closeMatch skos:notation .
 
 linkml:transitive a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -750,6 +749,14 @@ linkml:traverse a owl:ObjectProperty,
     rdfs:label "traverse" ;
     rdfs:range linkml:SlotDefinition ;
     skos:definition "the slot to traverse" .
+
+linkml:traverse_up a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "traverse_up" ;
+    rdfs:domain linkml:ReachabilityQuery ;
+    rdfs:range linkml:Boolean ;
+    skos:altLabel "ancestors" ;
+    skos:definition "True if the direction of the reachability query is reversed and ancestors are retrieved" .
 
 linkml:tree_root a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -774,15 +781,7 @@ linkml:types a owl:ObjectProperty,
     rdfs:label "types" ;
     rdfs:domain linkml:SchemaDefinition ;
     rdfs:range linkml:TypeDefinition ;
-    skos:definition "data types used in the model" .
-
-linkml:union_of a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "union_of" ;
-    rdfs:domain linkml:ClassDefinition ;
-    rdfs:range linkml:ClassDefinition ;
-    skos:definition "indicates that the domain class consists exactly of the members of the classes in the range" ;
-    skos:editorialNote "this only applies in the OWL generation" .
+    skos:definition "An index to the collection of all type definitions in the schema" .
 
 linkml:unique_key_name a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -796,7 +795,7 @@ linkml:unique_keys a owl:ObjectProperty,
     rdfs:label "unique_keys" ;
     rdfs:domain linkml:ClassDefinition ;
     rdfs:range linkml:UniqueKey ;
-    skos:definition "Set of unique keys for this slot" ;
+    skos:definition "A collection of unique keys for this class. Unique keys may be singular or compound." ;
     skos:exactMatch owl:hasKey .
 
 linkml:uri a owl:ObjectProperty,
@@ -820,7 +819,7 @@ linkml:values_from a owl:ObjectProperty,
     rdfs:label "values_from" ;
     rdfs:domain linkml:Definition ;
     rdfs:range linkml:Uriorcurie ;
-    skos:definition "the identifier of a \"value set\" -- a set of identifiers that form the possible values for the range of a slot" .
+    skos:definition "The identifier of a \"value set\" -- a set of identifiers that form the possible values for the range of a slot. Note: this is different than 'subproperty_of' in that 'subproperty_of' is intended to be a single ontology term while 'values_from' is the identifier of an entire value set.  Additionally, this is different than an enumeration in that in an enumeration, the values of the enumeration are listed directly in the model itself. Setting this property on a slot does not guarantee an expansion of the ontological hiearchy into an enumerated list of possible values in every serialization of the model." .
 
 oslc:modifiedBy a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -889,15 +888,44 @@ pav:version a owl:ObjectProperty,
     rdfs:range linkml:String ;
     skos:definition "particular version of schema" ;
     skos:exactMatch pav:version,
-        schema1:schemaVersion .
+        schema:schemaVersion .
 
-schema1:keywords a owl:ObjectProperty,
+qudt:hasQuantityKind a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "has_quantity_kind" ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:definition "Concept in a vocabulary or ontology that denotes the kind of quanity being measured, e.g. length" ;
+    skos:exactMatch qudt:hasQuantityKind ;
+    skos:note "Potential ontologies include but are not limited to PATO, NCIT, OBOE, qudt.quantityKind" .
+
+qudt:iec61360Code a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "iec61360code" ;
+    rdfs:range linkml:String ;
+    skos:exactMatch qudt:iec61360Code .
+
+qudt:symbol a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "symbol" ;
+    rdfs:range linkml:String ;
+    skos:definition "name of the unit encoded as a symbol" ;
+    skos:exactMatch qudt:symbol .
+
+qudt:ucumCode a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "ucum_code" ;
+    rdfs:domain linkml:UnitOfMeasure ;
+    rdfs:range linkml:String ;
+    skos:definition "associates a QUDT unit with its UCUM code (case-sensitive)." ;
+    skos:exactMatch qudt:ucumCode .
+
+schema:keywords a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "keywords" ;
     rdfs:domain linkml:Element ;
     rdfs:range linkml:String ;
     skos:definition "Keywords or tags used to describe the element" ;
-    skos:exactMatch schema1:keywords .
+    skos:exactMatch schema:keywords .
 
 rdf:object a owl:Class,
         linkml:RelationalRoleEnum ;
@@ -920,8 +948,9 @@ rdfs:subPropertyOf a owl:ObjectProperty,
     rdfs:label "subproperty_of" ;
     rdfs:domain linkml:SlotDefinition ;
     rdfs:range linkml:SlotDefinition ;
-    skos:definition "Ontology property which this slot is a subproperty of" ;
-    skos:exactMatch rdfs:subPropertyOf .
+    skos:definition "Ontology property which this slot is a subproperty of.  Note: setting this property on a slot does not guarantee an expansion of the ontological hiearchy into an enumerated list of possible values in every serialization of the model." ;
+    skos:exactMatch rdfs:subPropertyOf ;
+    linkml:examples "Example(value='RO:HOM0000001', description='this is the RO term for \"in homology relationship with\", and used as a value of subproperty of this means that any ontological child (related to RO:HOM0000001 via an is_a relationship), is a valid value for the slot that declares this with the subproperty_of tag.  This differs from the \\'values_from\\' meta model component in that \\'values_from\\' requires the id of a value set (said another way, if an entire ontology had a curie/identifier that was the identifier for the entire ontology, then that identifier would be used in \\'values_from.\\')')" .
 
 owl:inverseOf a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -970,32 +999,56 @@ linkml:AnonymousExpression a owl:Class,
     rdfs:label "anonymous_expression" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty skos:definition ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uri ;
             owl:onProperty skos:inScheme ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Example ;
-            owl:onProperty linkml:examples ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:deprecated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:editorialNote ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AltDescription ;
+            owl:onProperty linkml:alt_descriptions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Annotation ;
+            owl:onProperty linkml:annotations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:altLabel ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ],
+            owl:onProperty rdfs:seeAlso ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty linkml:imported_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:mappingRelation ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
@@ -1004,61 +1057,37 @@ linkml:AnonymousExpression a owl:Class,
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:relatedMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
+            owl:allValuesFrom linkml:Example ;
+            owl:onProperty linkml:examples ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:exactMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty linkml:todos ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Annotation ;
-            owl:onProperty linkml:annotations ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:broadMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+            owl:onProperty dcterms:source ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:SubsetDefinition ;
             owl:onProperty OIO:inSubset ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:deprecated ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:narrowMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty rdfs:seeAlso ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:mappingRelation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty dcterms:source ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AltDescription ;
-            owl:onProperty linkml:alt_descriptions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:altLabel ],
+            owl:onProperty skos:closeMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty skos:definition ],
+            owl:onProperty schema:inLanguage ],
         linkml:Annotatable,
         linkml:CommonMetadata,
         linkml:Expression,
@@ -1074,57 +1103,90 @@ linkml:ClassRule a owl:Class,
     rdfs:label "class_rule" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:altLabel ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
+            owl:onProperty linkml:imported_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:broadMatch ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:deprecated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Annotation ;
+            owl:onProperty linkml:annotations ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:postconditions ],
+            owl:onProperty sh:condition ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ],
+            owl:onProperty schema:inLanguage ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SubsetDefinition ;
-            owl:onProperty OIO:inSubset ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
+            owl:onProperty skos:mappingRelation ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty linkml:deprecated_element_has_possible_replacement ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty linkml:todos ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uri ;
-            owl:onProperty skos:inScheme ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
+            owl:onClass linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:elseconditions ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty dcterms:source ],
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty sh:deactivated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:editorialNote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SubsetDefinition ;
+            owl:onProperty OIO:inSubset ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty skos:definition ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:open_world ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty dcterms:source ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:postconditions ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:bidirectional ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty rdfs:seeAlso ],
@@ -1132,68 +1194,35 @@ linkml:ClassRule a owl:Class,
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:narrowMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Annotation ;
-            owl:onProperty linkml:annotations ],
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:exactMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:AltDescription ;
             owl:onProperty linkml:alt_descriptions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:mappingRelation ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:elseconditions ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Example ;
             owl:onProperty linkml:examples ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:deprecated ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AnonymousClassExpression ;
-            owl:onProperty sh1:condition ],
+            owl:onClass linkml:Uri ;
+            owl:onProperty skos:inScheme ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty sh1:deactivated ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:broadMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:bidirectional ],
+            owl:onProperty skos:closeMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:open_world ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:altLabel ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+            owl:onProperty dcterms:title ],
         linkml:Annotatable,
         linkml:ClassLevelRule,
         linkml:CommonMetadata,
         linkml:Extensible ;
     skos:altLabel "if rule" ;
     skos:closeMatch swrl:Imp,
-        sh1:TripleRule ;
+        sh:TripleRule ;
     skos:definition "A rule that applies to instances of a class" .
 
 <https://w3id.org/linkml/PresenceEnum#ABSENT> a owl:Class,
@@ -1238,27 +1267,43 @@ linkml:TypeExpression a owl:Class,
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:equals_string ],
+            owl:onProperty linkml:implicit_prefix ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:UnitOfMeasure ;
+            owl:onProperty qudt:unit ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:maximum_value ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:AnonymousTypeExpression ;
             owl:onProperty linkml:all_of ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:none_of ],
+            owl:onProperty linkml:exactly_one_of ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:exactly_one_of ],
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PatternExpression ;
+            owl:onProperty linkml:structured_pattern ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty linkml:pattern ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:any_of ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_value ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:PatternExpression ;
-            owl:onProperty linkml:structured_pattern ],
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:equals_string ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousTypeExpression ;
+            owl:onProperty linkml:any_of ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty linkml:equals_string_in ],
@@ -1266,14 +1311,6 @@ linkml:TypeExpression a owl:Class,
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Integer ;
             owl:onProperty linkml:equals_number ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:maximum_value ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_value ],
         linkml:Expression,
         linkml:mixin .
 
@@ -1301,6 +1338,14 @@ linkml:slot_names_unique a owl:ObjectProperty,
 linkml:slots a owl:ObjectProperty,
         linkml:SlotDefinition .
 
+linkml:source_ontology a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "source_ontology" ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:altLabel "terminology",
+        "vocabulary" ;
+    skos:definition "An ontology or vocabulary or terminology that is used in a query to obtain a set of permissible values" .
+
 linkml:transitive_form_of a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "transitive_form_of" ;
@@ -1315,7 +1360,7 @@ linkml:unique_key_slots a owl:ObjectProperty,
     rdfs:range linkml:SlotDefinition ;
     skos:definition "list of slot names that form a key" .
 
-sh1:condition a owl:ObjectProperty,
+sh:condition a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "preconditions" ;
     rdfs:range linkml:AnonymousClassExpression ;
@@ -1324,30 +1369,54 @@ sh1:condition a owl:ObjectProperty,
         "if" ;
     skos:closeMatch swrl:body ;
     skos:definition "an expression that must hold in order for the rule to be applicable to an instance" ;
-    skos:exactMatch sh1:condition .
+    skos:exactMatch sh:condition .
 
-sh1:deactivated a owl:ObjectProperty,
+sh:deactivated a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "deactivated" ;
     rdfs:range linkml:Boolean ;
     skos:definition "a deactivated rule is not executed by the rules engine" ;
-    skos:exactMatch sh1:deactivated .
+    skos:exactMatch sh:deactivated .
 
-sh1:group a owl:ObjectProperty,
+sh:declare a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "prefixes" ;
+    rdfs:domain linkml:SchemaDefinition ;
+    rdfs:range linkml:Prefix ;
+    skos:definition "prefix / URI definitions to be added to the context beyond those fetched from prefixcommons in id prefixes" ;
+    skos:exactMatch sh:declare .
+
+sh:group a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "slot_group" ;
     rdfs:domain linkml:SlotDefinition ;
     rdfs:range linkml:SlotDefinition ;
     skos:definition "allows for grouping of related slots into a grouping slot that serves the role of a group" ;
-    skos:exactMatch sh1:group .
+    skos:exactMatch sh:group .
 
-sh1:rule a owl:ObjectProperty,
+sh:namespace a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "prefix_reference" ;
+    rdfs:domain linkml:Prefix ;
+    rdfs:range linkml:Uri ;
+    skos:definition "A URI associated with a given prefix" ;
+    skos:exactMatch sh:namespace .
+
+sh:prefix a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "prefix_prefix" ;
+    rdfs:domain linkml:Prefix ;
+    rdfs:range linkml:Ncname ;
+    skos:definition "the nsname (sans ':' for a given prefix)" ;
+    skos:exactMatch sh:prefix .
+
+sh:rule a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "rules" ;
     rdfs:domain linkml:ClassDefinition ;
     rdfs:range linkml:ClassRule ;
     skos:definition "the collection of rules that apply to all members of this class" ;
-    skos:exactMatch sh1:rule .
+    skos:exactMatch sh:rule .
 
 dcterms:subject a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -1365,46 +1434,15 @@ rdfs:label a owl:ObjectProperty,
     skos:altLabel "short name",
         "unique name" ;
     skos:definition "the unique name of the element within the context of the schema.  Name is combined with the default prefix to form the globally unique subject of the target class." ;
-    skos:exactMatch schema1:name,
+    skos:exactMatch schema:name,
         rdfs:label .
-
-linkml:ClassExpression a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "class_expression" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:exactly_one_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:slot_conditions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:none_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:all_of ],
-        linkml:mixin ;
-    skos:definition "A boolean expression that can be used to dynamically determine membership of a class" .
 
 linkml:all_members a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "all_members" ;
-    rdfs:range linkml:SlotDefinition ;
+    rdfs:range linkml:AnonymousSlotExpression ;
     rdfs:subPropertyOf linkml:list_value_specification_constant ;
-    skos:definition """the value of the multiavlued slot is a list where all elements conform to the specified values.
-this defines a dynamic class with named slots according to matching constraints
-
-E.g to state that all members of a list are between 1 and 10
-```
-all_members:
-  x:
-    range: integer
-    minimum_value: 10
-    maximum_value: 10
-```""" .
+    skos:definition "the value of the slot is multivalued with all members satisfying the condition" .
 
 linkml:apply_to a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -1412,6 +1450,42 @@ linkml:apply_to a owl:ObjectProperty,
     rdfs:domain linkml:Definition ;
     rdfs:range linkml:Definition ;
     skos:definition "Used to extend class or slot definitions. For example, if we have a core schema where a gene has two slots for identifier and symbol, and we have a specialized schema for my_organism where we wish to add a slot systematic_name, we can avoid subclassing by defining a class gene_my_organism, adding the slot to this class, and then adding an apply_to pointing to the gene class. The new slot will be 'injected into' the gene class." .
+
+linkml:code_set a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "code_set" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:definition "the identifier of an enumeration code set." .
+
+linkml:code_set_tag a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "code_set_tag" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:String ;
+    skos:definition "the version tag of the enumeration code set" ;
+    skos:note "enum_expression cannot have both a code_set_tag and a code_set_version" .
+
+linkml:code_set_version a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "code_set_version" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:String ;
+    skos:definition "the version identifier of the enumeration code set" ;
+    skos:note "we assume that version identifiers lexically sort in temporal order. Recommend semver when possible" .
+
+linkml:concepts a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "concepts" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:definition "A list of identifiers that are used to construct a set of permissible values" .
+
+linkml:enum_range a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "enum_range" ;
+    rdfs:range linkml:EnumExpression ;
+    skos:definition "An inlined enumeration" .
 
 linkml:equals_expression a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -1427,14 +1501,22 @@ linkml:has_member a owl:ObjectProperty,
     rdfs:label "has_member" ;
     rdfs:range linkml:AnonymousSlotExpression ;
     rdfs:subPropertyOf linkml:list_value_specification_constant ;
-    skos:definition "the values of the slot is multivalued with at least one member satisfying the condition" .
+    skos:definition "the value of the slot is multivalued with at least one member satisfying the condition" .
 
-linkml:implicit_prefix a owl:ObjectProperty,
+linkml:include a owl:ObjectProperty,
         linkml:SlotDefinition ;
-    rdfs:label "implicit_prefix" ;
-    rdfs:domain linkml:SlotExpression ;
-    rdfs:range linkml:String ;
-    skos:definition "Causes the slot value to be interpreted as a uriorcurie after prefixing with this string" .
+    rdfs:label "include" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:AnonymousEnumExpression ;
+    skos:definition "An enum expression that yields a list of permissible values that are to be included, after subtracting the minus set" .
+
+linkml:inherits a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "inherits" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:EnumDefinition ;
+    skos:definition "An enum definition that is used as the basis to create a new enum" ;
+    skos:note "All permissible values for all inherited enums are copied to form the initial seed set" .
 
 linkml:inlined a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -1456,6 +1538,13 @@ to the inlined_as_list setting.""",
         """The default loader will accept either list or dictionary form as input.  This parameter controls internal
 representation and output.""" .
 
+linkml:matches a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "matches" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:MatchQuery ;
+    skos:definition "Specifies a match query that is used to calculate the list of permissible values" .
+
 linkml:maximum_cardinality a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "maximum_cardinality" ;
@@ -1469,6 +1558,29 @@ linkml:minimum_cardinality a owl:ObjectProperty,
     rdfs:range linkml:Integer ;
     rdfs:subPropertyOf linkml:list_value_specification_constant ;
     skos:definition "the minimum number of entries for a multivalued slot" .
+
+linkml:minus a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "minus" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:AnonymousEnumExpression ;
+    skos:definition "An enum expression that yields a list of permissible values that are to be subtracted from the enum" .
+
+linkml:permissible_values a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "permissible_values" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:PermissibleValue ;
+    skos:definition "A list of possible values for a slot range" .
+
+linkml:pv_formula a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "pv_formula" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:PvFormulaOptions ;
+    skos:definition "Defines the specific formula to be used to generate the permissible values." ;
+    skos:note "code_set must be supplied for this to be valid",
+        "you cannot have BOTH the permissible_values and permissible_value_formula tag" .
 
 linkml:range a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -1487,6 +1599,13 @@ the declaration
 implicitly asserts Y is an instance of C2
 """ ;
     skos:note "range is underspecified, as not all elements can appear as the range of a slot." .
+
+linkml:reachable_from a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "reachable_from" ;
+    rdfs:domain linkml:EnumExpression ;
+    rdfs:range linkml:ReachabilityQuery ;
+    skos:definition "Specifies a query for obtaining a list of permissible values based on graph reachability" .
 
 linkml:recommended a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -1508,8 +1627,26 @@ linkml:required a owl:ObjectProperty,
 linkml:slot_conditions a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "slot_conditions" ;
+    rdfs:domain linkml:ClassExpression ;
     rdfs:range linkml:SlotDefinition ;
-    skos:definition "the redefinition of a slot in the context of the containing class definition." .
+    skos:definition "expresses constraints on a group of slots for a class expression" .
+
+linkml:union_of a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "union_of" ;
+    rdfs:domain linkml:Element ;
+    rdfs:range linkml:Element ;
+    skos:definition "indicates that the domain element consists exactly of the members of the element in the range." ;
+    skos:editorialNote "this only applies in the OWL generation" .
+
+linkml:value_presence a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "value_presence" ;
+    rdfs:domain linkml:SlotDefinition ;
+    rdfs:range linkml:PresenceEnum ;
+    rdfs:subPropertyOf linkml:list_value_specification_constant ;
+    skos:definition "if true then a value must be present (for lists there must be at least one value). If false then a value must be absent (for lists, must be empty)" ;
+    skos:note "if set to true this has the same effect as required=true. In contrast, required=false allows a value to be present" .
 
 rdf:predicate a owl:Class,
         owl:ObjectProperty,
@@ -1522,111 +1659,132 @@ rdf:predicate a owl:Class,
     skos:definition "The relationship between an element and its alias " ;
     skos:exactMatch rdf:predicate .
 
+linkml:ClassExpression a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "class_expression" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:exactly_one_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:all_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SlotDefinition ;
+            owl:onProperty linkml:slot_conditions ],
+        linkml:mixin ;
+    skos:definition "A boolean expression that can be used to dynamically determine membership of a class" .
+
 linkml:ImportExpression a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "import_expression" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Ncname ;
-            owl:onProperty linkml:import_as ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:altLabel ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:mappingRelation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:relatedMatch ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty skos:definition ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:deprecated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:todos ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:editorialNote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:altLabel ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty rdfs:seeAlso ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:mappingRelation ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:broadMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AltDescription ;
-            owl:onProperty linkml:alt_descriptions ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:closeMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+            owl:onClass linkml:Ncname ;
+            owl:onProperty linkml:import_as ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Setting ;
+            owl:onProperty linkml:import_map ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uri ;
+            owl:onProperty skos:inScheme ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:imported_from ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty dcterms:title ],
         [ a owl:Restriction ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty linkml:import_from ;
             owl:qualifiedCardinality 1 ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty dcterms:source ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AltDescription ;
+            owl:onProperty linkml:alt_descriptions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:exactMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Annotation ;
+            owl:onProperty linkml:annotations ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:deprecated ],
+            owl:onProperty schema:inLanguage ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Example ;
             owl:onProperty linkml:examples ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:SubsetDefinition ;
             owl:onProperty OIO:inSubset ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:todos ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty rdfs:seeAlso ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Setting ;
-            owl:onProperty linkml:import_map ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Annotation ;
-            owl:onProperty linkml:annotations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uri ;
-            owl:onProperty skos:inScheme ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty dcterms:source ],
         linkml:Annotatable,
         linkml:CommonMetadata,
         linkml:Extensible ;
@@ -1645,93 +1803,16 @@ linkml:LocalName a owl:Class,
             owl:qualifiedCardinality 1 ] ;
     skos:definition "an attributed label" .
 
-linkml:PresenceEnum a owl:Class,
-        linkml:EnumDefinition ;
-    rdfs:label "presence_enum" ;
-    owl:unionOf ( <https://w3id.org/linkml/PresenceEnum#UNCOMMITTED> <https://w3id.org/linkml/PresenceEnum#PRESENT> <https://w3id.org/linkml/PresenceEnum#ABSENT> ) ;
-    linkml:permissible_values <https://w3id.org/linkml/PresenceEnum#ABSENT>,
-        <https://w3id.org/linkml/PresenceEnum#PRESENT>,
-        <https://w3id.org/linkml/PresenceEnum#UNCOMMITTED> .
-
 linkml:SlotExpression a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "slot_expression" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:equals_string_in ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:inlined_as_list ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:equals_string ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:PatternExpression ;
-            owl:onProperty linkml:structured_pattern ],
+            owl:onClass linkml:EnumExpression ;
+            owl:onProperty linkml:enum_range ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:exactly_one_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_value ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:maximum_cardinality ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:has_member ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:range_expression ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:maximum_value ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:recommended ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:pattern ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:equals_number ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_cardinality ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:inlined ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:required ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:all_members ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:equals_expression ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Element ;
-            owl:onProperty linkml:range ],
+            owl:onProperty linkml:all_of ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
@@ -1740,8 +1821,90 @@ linkml:SlotExpression a owl:Class,
             owl:allValuesFrom linkml:AnonymousSlotExpression ;
             owl:onProperty linkml:none_of ],
         [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:has_member ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_cardinality ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:UnitOfMeasure ;
+            owl:onProperty qudt:unit ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PresenceEnum ;
+            owl:onProperty linkml:value_presence ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:maximum_cardinality ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:all_of ],
+            owl:onProperty linkml:exactly_one_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:maximum_value ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:equals_string ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:required ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:pattern ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:equals_string_in ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:inlined_as_list ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PatternExpression ;
+            owl:onProperty linkml:structured_pattern ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:equals_expression ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_value ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Element ;
+            owl:onProperty linkml:range ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:recommended ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:range_expression ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:equals_number ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:all_members ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:inlined ],
         linkml:Expression,
         linkml:mixin ;
     skos:definition "an expression that constrains the range of values a slot can take" .
@@ -1750,50 +1913,13 @@ linkml:UniqueKey a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "unique_key" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:narrowMatch ],
-        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:unique_key_name ;
-            owl:qualifiedCardinality 1 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty rdfs:seeAlso ],
+            owl:onProperty linkml:imported_from ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
-        [ a owl:Class ;
-            owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:allValuesFrom linkml:SlotDefinition ;
-                        owl:onProperty linkml:unique_key_slots ] [ a owl:Restriction ;
-                        owl:onProperty linkml:unique_key_slots ;
-                        owl:someValuesFrom linkml:SlotDefinition ] ) ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:deprecated ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Example ;
-            owl:onProperty linkml:examples ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AltDescription ;
-            owl:onProperty linkml:alt_descriptions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:altLabel ],
+            owl:onProperty dcterms:source ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uri ;
@@ -1801,55 +1927,92 @@ linkml:UniqueKey a owl:Class,
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty dcterms:source ],
+            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:todos ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:relatedMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Annotation ;
-            owl:onProperty linkml:annotations ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:broadMatch ],
         [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:closeMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
         [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:todos ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Example ;
+            owl:onProperty linkml:examples ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Annotation ;
+            owl:onProperty linkml:annotations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AltDescription ;
+            owl:onProperty linkml:alt_descriptions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty rdfs:seeAlso ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:exactMatch ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:deprecated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SubsetDefinition ;
+            owl:onProperty OIO:inSubset ],
+        [ a owl:Class ;
+            owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:allValuesFrom linkml:SlotDefinition ;
+                        owl:onProperty linkml:unique_key_slots ] [ a owl:Restriction ;
+                        owl:onProperty linkml:unique_key_slots ;
+                        owl:someValuesFrom linkml:SlotDefinition ] ) ],
+        [ a owl:Restriction ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:unique_key_name ;
+            owl:qualifiedCardinality 1 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:editorialNote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:altLabel ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:mappingRelation ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
+            owl:onProperty skos:definition ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
+            owl:onProperty skos:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty skos:definition ],
+            owl:onProperty dcterms:title ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SubsetDefinition ;
-            owl:onProperty OIO:inSubset ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty schema:inLanguage ],
         linkml:Annotatable,
         linkml:CommonMetadata,
         linkml:Extensible ;
@@ -1868,7 +2031,7 @@ linkml:mixins a owl:ObjectProperty,
     rdfs:range linkml:Definition ;
     rdfs:seeAlso "https://en.wikipedia.org/wiki/Mixin" ;
     skos:altLabel "traits" ;
-    skos:definition "List of definitions to be mixed in. Targets may be any definition of the same type" ;
+    skos:definition "A collection of secondary parent classes or slots from which inheritable metaslots are propagated from." ;
     skos:note "mixins act in the same way as parents (is_a). They allow a model to have a primary strict hierachy, while keeping the benefits of multiple inheritance" .
 
 linkml:range_expression a owl:ObjectProperty,
@@ -1884,11 +2047,11 @@ linkml:Prefix a owl:Class,
     rdfs:label "prefix" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onClass linkml:Uri ;
-            owl:onProperty linkml:prefix_reference ;
+            owl:onProperty sh:namespace ;
             owl:qualifiedCardinality 1 ],
         [ a owl:Restriction ;
             owl:onClass linkml:Ncname ;
-            owl:onProperty linkml:prefix_prefix ;
+            owl:onProperty sh:prefix ;
             owl:qualifiedCardinality 1 ] ;
     skos:definition "prefix URI tuple" .
 
@@ -1897,7 +2060,7 @@ linkml:is_a a owl:ObjectProperty,
     rdfs:label "is_a" ;
     rdfs:domain linkml:Definition ;
     rdfs:range linkml:Definition ;
-    skos:definition "specifies single-inheritance between classes or slots. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded" .
+    skos:definition "A primary parent class or slot from which inheritable metaslots are propagated from. While multiple inheritance is not allowed, mixins can be provided effectively providing the same thing. The semantics are the same when translated to formalisms that allow MI (e.g. RDFS/OWL). When translating to a SI framework (e.g. java classes, python classes) then is a is used. When translating a framework without polymorphism (e.g. json-schema, solr document schema) then is a and mixins are recursively unfolded" .
 
 linkml:AliasPredicateEnum a owl:Class,
         linkml:EnumDefinition ;
@@ -1908,129 +2071,18 @@ linkml:AliasPredicateEnum a owl:Class,
         skos:narrowerMatch,
         skos:relatedMatch .
 
-linkml:PermissibleValue a owl:Class,
+linkml:MatchQuery a owl:Class,
         linkml:ClassDefinition ;
-    rdfs:label "permissible_value" ;
+    rdfs:label "match_query" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AltDescription ;
-            owl:onProperty linkml:alt_descriptions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:PermissibleValue ;
-            owl:onProperty linkml:mixins ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Annotation ;
-            owl:onProperty linkml:annotations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:mappingRelation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SubsetDefinition ;
-            owl:onProperty OIO:inSubset ],
+            owl:onProperty linkml:identifier_pattern ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:meaning ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:broadMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty skos:definition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty rdfs:seeAlso ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:altLabel ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Example ;
-            owl:onProperty linkml:examples ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty dcterms:source ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uri ;
-            owl:onProperty skos:inScheme ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:todos ],
-        [ a owl:Restriction ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:text ;
-            owl:qualifiedCardinality 1 ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:deprecated ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:PermissibleValue ;
-            owl:onProperty linkml:is_a ],
-        linkml:Annotatable,
-        linkml:CommonMetadata,
-        linkml:Extensible ;
-    skos:altLabel "PV" ;
-    skos:definition "a permissible value, accompanied by intended text and an optional mapping to a concept URI" .
-
-linkml:PvFormulaOptions a owl:Class,
-        linkml:EnumDefinition ;
-    rdfs:label "pv_formula_options" ;
-    owl:unionOf ( <https://w3id.org/linkml/PvFormulaOptions#CODE> <https://w3id.org/linkml/PvFormulaOptions#CURIE> <https://w3id.org/linkml/PvFormulaOptions#URI> <https://w3id.org/linkml/PvFormulaOptions#FHIR_CODING> ) ;
-    linkml:permissible_values <https://w3id.org/linkml/PvFormulaOptions#CODE>,
-        <https://w3id.org/linkml/PvFormulaOptions#CURIE>,
-        <https://w3id.org/linkml/PvFormulaOptions#FHIR_CODING>,
-        <https://w3id.org/linkml/PvFormulaOptions#URI> .
+            owl:onProperty linkml:source_ontology ] ;
+    skos:definition "A query that is used on an enum expression to dynamically obtain a set of permissivle values via a query that matches on properties of the external concepts" .
 
 linkml:equals_number a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2052,6 +2104,13 @@ linkml:equals_string_in a owl:ObjectProperty,
     rdfs:range linkml:String ;
     rdfs:subPropertyOf linkml:list_value_specification_constant ;
     skos:definition "the slot must have range string and the value of the slot must equal one of the specified values" .
+
+linkml:implicit_prefix a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "implicit_prefix" ;
+    rdfs:domain linkml:SlotExpression ;
+    rdfs:range linkml:String ;
+    skos:definition "Causes the slot value to be interpreted as a uriorcurie after prefixing with this string" .
 
 linkml:maximum_value a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2094,83 +2153,6 @@ linkml:PathExpression a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "path_expression" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:PathExpression ;
-            owl:onProperty linkml:all_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AltDescription ;
-            owl:onProperty linkml:alt_descriptions ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty dcterms:source ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty rdfs:seeAlso ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uri ;
-            owl:onProperty skos:inScheme ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:reversed ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:broadMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty skos:definition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:PathExpression ;
-            owl:onProperty linkml:none_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:PathExpression ;
-            owl:onProperty linkml:exactly_one_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:SlotDefinition ;
-            owl:onProperty linkml:traverse ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:todos ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:AnonymousClassExpression ;
             owl:onProperty linkml:range_expression ],
@@ -2179,44 +2161,129 @@ linkml:PathExpression a owl:Class,
             owl:onProperty linkml:examples ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:PathExpression ;
-            owl:onProperty linkml:followed_by ],
+            owl:onClass linkml:SlotDefinition ;
+            owl:onProperty linkml:traverse ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Annotation ;
-            owl:onProperty linkml:annotations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:PathExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:mappingRelation ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty linkml:deprecated ],
         [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty skos:definition ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty dcterms:source ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:PathExpression ;
+            owl:onProperty linkml:exactly_one_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:editorialNote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:PathExpression ;
+            owl:onProperty linkml:all_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uri ;
+            owl:onProperty skos:inScheme ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:closeMatch ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty schema:inLanguage ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:PathExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:PathExpression ;
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:todos ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Annotation ;
+            owl:onProperty linkml:annotations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:mappingRelation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:broadMatch ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty skos:altLabel ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:SubsetDefinition ;
             owl:onProperty OIO:inSubset ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:narrowMatch ],
+            owl:onProperty skos:exactMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AltDescription ;
+            owl:onProperty linkml:alt_descriptions ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PathExpression ;
+            owl:onProperty linkml:followed_by ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:imported_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty rdfs:seeAlso ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:reversed ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty dcterms:title ],
         linkml:Annotatable,
         linkml:CommonMetadata,
         linkml:Expression,
         linkml:Extensible ;
     skos:definition "An expression that describes an abstract path from an object to another through a sequence of slot lookups" .
+
+linkml:PresenceEnum a owl:Class,
+        linkml:EnumDefinition ;
+    rdfs:label "presence_enum" ;
+    owl:unionOf ( <https://w3id.org/linkml/PresenceEnum#UNCOMMITTED> <https://w3id.org/linkml/PresenceEnum#PRESENT> <https://w3id.org/linkml/PresenceEnum#ABSENT> ) ;
+    linkml:permissible_values <https://w3id.org/linkml/PresenceEnum#ABSENT>,
+        <https://w3id.org/linkml/PresenceEnum#PRESENT>,
+        <https://w3id.org/linkml/PresenceEnum#UNCOMMITTED> .
 
 linkml:RelationalRoleEnum a owl:Class,
         linkml:EnumDefinition ;
@@ -2232,14 +2299,195 @@ linkml:Setting a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "setting" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:onClass linkml:Ncname ;
-            owl:onProperty linkml:setting_key ;
-            owl:qualifiedCardinality 1 ],
-        [ a owl:Restriction ;
             owl:onClass linkml:String ;
             owl:onProperty linkml:setting_value ;
+            owl:qualifiedCardinality 1 ],
+        [ a owl:Restriction ;
+            owl:onClass linkml:Ncname ;
+            owl:onProperty linkml:setting_key ;
             owl:qualifiedCardinality 1 ] ;
     skos:definition "assignment of a key to a value" .
+
+qudt:unit a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "unit" ;
+    rdfs:range linkml:UnitOfMeasure ;
+    skos:definition "an encoding of a unit" ;
+    skos:exactMatch qudt:unit .
+
+linkml:AnonymousEnumExpression a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "anonymous_enum_expression" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousEnumExpression ;
+            owl:onProperty linkml:minus ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty linkml:concepts ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:code_set_tag ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PvFormulaOptions ;
+            owl:onProperty linkml:pv_formula ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:ReachabilityQuery ;
+            owl:onProperty linkml:reachable_from ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:MatchQuery ;
+            owl:onProperty linkml:matches ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:EnumDefinition ;
+            owl:onProperty linkml:inherits ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:code_set ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:code_set_version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:PermissibleValue ;
+            owl:onProperty linkml:permissible_values ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousEnumExpression ;
+            owl:onProperty linkml:include ],
+        linkml:EnumExpression ;
+    skos:definition "An enum_expression that is not named" .
+
+linkml:PermissibleValue a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "permissible_value" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:mappingRelation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:PermissibleValue ;
+            owl:onProperty linkml:mixins ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty dcterms:source ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:broadMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:altLabel ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:exactMatch ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:meaning ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:todos ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty dcterms:title ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:closeMatch ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uri ;
+            owl:onProperty skos:inScheme ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty schema:inLanguage ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:imported_from ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SubsetDefinition ;
+            owl:onProperty OIO:inSubset ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:deprecated ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:UnitOfMeasure ;
+            owl:onProperty qudt:unit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:editorialNote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Annotation ;
+            owl:onProperty linkml:annotations ],
+        [ a owl:Restriction ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:text ;
+            owl:qualifiedCardinality 1 ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PermissibleValue ;
+            owl:onProperty linkml:is_a ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty rdfs:seeAlso ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty skos:definition ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AltDescription ;
+            owl:onProperty linkml:alt_descriptions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Example ;
+            owl:onProperty linkml:examples ],
+        linkml:Annotatable,
+        linkml:CommonMetadata,
+        linkml:Extensible ;
+    skos:altLabel "PV" ;
+    skos:closeMatch skos:Concept ;
+    skos:definition "a permissible value, accompanied by intended text and an optional mapping to a concept URI" .
+
+linkml:PvFormulaOptions a owl:Class,
+        linkml:EnumDefinition ;
+    rdfs:label "pv_formula_options" ;
+    owl:unionOf ( <https://w3id.org/linkml/PvFormulaOptions#CODE> <https://w3id.org/linkml/PvFormulaOptions#CURIE> <https://w3id.org/linkml/PvFormulaOptions#URI> <https://w3id.org/linkml/PvFormulaOptions#FHIR_CODING> ) ;
+    linkml:permissible_values <https://w3id.org/linkml/PvFormulaOptions#CODE>,
+        <https://w3id.org/linkml/PvFormulaOptions#CURIE>,
+        <https://w3id.org/linkml/PvFormulaOptions#FHIR_CODING>,
+        <https://w3id.org/linkml/PvFormulaOptions#URI> .
 
 linkml:mixin a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2248,96 +2496,96 @@ linkml:mixin a owl:ObjectProperty,
     rdfs:range linkml:Boolean ;
     rdfs:seeAlso "https://en.wikipedia.org/wiki/Mixin" ;
     skos:altLabel "trait" ;
-    skos:definition "this slot or class can only be used as a mixin." .
+    skos:definition "Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins." .
 
 linkml:CommonMetadata a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "common_metadata" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty dcterms:source ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:mappingRelation ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty skos:altLabel ],
         [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uri ;
-            owl:onProperty skos:inScheme ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:todos ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty rdfs:seeAlso ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AltDescription ;
-            owl:onProperty linkml:alt_descriptions ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:closeMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
+            owl:onProperty sh:order ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Example ;
-            owl:onProperty linkml:examples ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:deprecated ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty skos:editorialNote ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty schema:inLanguage ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:SubsetDefinition ;
             owl:onProperty OIO:inSubset ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty dcterms:source ],
+            owl:onClass linkml:Uri ;
+            owl:onProperty skos:inScheme ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty skos:definition ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
+            owl:onProperty skos:exactMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AltDescription ;
+            owl:onProperty linkml:alt_descriptions ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:broadMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:deprecated ],
+            owl:onProperty linkml:imported_from ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty dcterms:title ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Example ;
+            owl:onProperty linkml:examples ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:narrowMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:StructuredAlias ;
             owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:todos ],
         linkml:mixin ;
     skos:definition "Generic metadata shared across definitions" .
 
@@ -2347,172 +2595,166 @@ linkml:PatternExpression a owl:Class,
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:deprecated ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:broadMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+            owl:onProperty dcterms:title ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty skos:note ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uri ;
-            owl:onProperty skos:inScheme ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:partial_match ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty skos:definition ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty dcterms:source ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SubsetDefinition ;
-            owl:onProperty OIO:inSubset ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:syntax ],
+            owl:onProperty linkml:imported_from ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:narrowMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Annotation ;
-            owl:onProperty linkml:annotations ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:broadMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:interpolated ],
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty rdfs:seeAlso ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
+            owl:allValuesFrom linkml:Example ;
+            owl:onProperty linkml:examples ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty linkml:todos ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:altLabel ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Extension ;
             owl:onProperty linkml:extensions ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:partial_match ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty skos:definition ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:relatedMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
+            owl:onProperty linkml:syntax ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Example ;
-            owl:onProperty linkml:examples ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:deprecated ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SubsetDefinition ;
+            owl:onProperty OIO:inSubset ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty schema:inLanguage ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:altLabel ],
+            owl:onProperty skos:editorialNote ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uri ;
+            owl:onProperty skos:inScheme ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Annotation ;
+            owl:onProperty linkml:annotations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty rdfs:seeAlso ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:exactMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:AltDescription ;
             owl:onProperty linkml:alt_descriptions ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:closeMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:mappingRelation ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:interpolated ],
         linkml:Annotatable,
         linkml:CommonMetadata,
         linkml:Extensible ;
     skos:definition "a regular expression pattern used to evaluate conformance of a string" .
 
-linkml:TypeDefinition a owl:Class,
+linkml:ReachabilityQuery a owl:Class,
         linkml:ClassDefinition ;
-    rdfs:label "type_definition" ;
+    rdfs:label "reachability_query" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:none_of ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:repr ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:equals_string ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:equals_number ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:pattern ],
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:traverse_up ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:uri ],
+            owl:onProperty linkml:source_ontology ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty linkml:relationship_types ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:is_direct ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty linkml:source_nodes ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:include_self ] ;
+    skos:definition "A query that is used on an enum expression to dynamically obtain a set of permissible values via walking from a set of source nodes to a set of descendants or ancestors over a set of relationship types" .
+
+linkml:UnitOfMeasure a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "UnitOfMeasure" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty qudt:symbol ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:exactMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:base ],
+            owl:onProperty qudt:iec61360Code ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:TypeDefinition ;
-            owl:onProperty linkml:typeof ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:exactly_one_of ],
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty qudt:hasQuantityKind ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:PatternExpression ;
-            owl:onProperty linkml:structured_pattern ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:equals_string_in ],
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:derivation ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:maximum_value ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:all_of ],
-        linkml:Element,
-        linkml:TypeExpression ;
-    skos:definition "A data type definition." .
+            owl:onClass linkml:String ;
+            owl:onProperty qudt:ucumCode ] ;
+    skos:definition "A unit of measure, or unit, is a particular quantity value that has been chosen as a scale for measuring other quantities the same kind (more generally of equivalent dimension)." ;
+    skos:exactMatch qudt:Unit .
 
 linkml:all_of a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2520,14 +2762,15 @@ linkml:all_of a owl:ObjectProperty,
     rdfs:range linkml:Expression ;
     rdfs:subPropertyOf linkml:boolean_slot ;
     skos:definition "holds if all of the expressions hold" ;
-    skos:exactMatch sh1:and .
+    skos:exactMatch sh:and .
 
 linkml:alt_descriptions a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "alt_descriptions" ;
     rdfs:domain linkml:Element ;
     rdfs:range linkml:AltDescription ;
-    skos:altLabel "alternate definitions" .
+    skos:altLabel "alternate definitions" ;
+    skos:definition "A sourced alternative description for an element" .
 
 linkml:any_of a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2535,7 +2778,7 @@ linkml:any_of a owl:ObjectProperty,
     rdfs:range linkml:Expression ;
     rdfs:subPropertyOf linkml:boolean_slot ;
     skos:definition "holds if at least one of the expressions hold" ;
-    skos:exactMatch sh1:or .
+    skos:exactMatch sh:or .
 
 linkml:deprecated a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2565,14 +2808,14 @@ linkml:exactly_one_of a owl:ObjectProperty,
     rdfs:range linkml:Expression ;
     rdfs:subPropertyOf linkml:boolean_slot ;
     skos:definition "holds if only one of the expressions hold" ;
-    skos:exactMatch sh1:xone .
+    skos:exactMatch sh:xone .
 
 linkml:examples a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "examples" ;
     rdfs:domain linkml:Element ;
     rdfs:range linkml:Example ;
-    skos:closeMatch vann1:example ;
+    skos:closeMatch vann:example ;
     skos:definition "example usages of an element" .
 
 linkml:imported_from a owl:ObjectProperty,
@@ -2594,7 +2837,7 @@ linkml:none_of a owl:ObjectProperty,
     rdfs:range linkml:Expression ;
     rdfs:subPropertyOf linkml:boolean_slot ;
     skos:definition "holds if none of the expressions hold" ;
-    skos:exactMatch sh1:not .
+    skos:exactMatch sh:not .
 
 linkml:todos a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2610,7 +2853,7 @@ dcterms:source a owl:ObjectProperty,
     rdfs:range linkml:Uriorcurie ;
     skos:altLabel "derived from",
         "origin" ;
-    skos:closeMatch schema1:isBasedOn,
+    skos:closeMatch schema:isBasedOn,
         prov:wasDerivedFrom ;
     skos:definition "A related resource from which the element is derived." ;
     skos:exactMatch dcterms:source ;
@@ -2625,12 +2868,12 @@ dcterms:title a owl:ObjectProperty,
     skos:definition "the official title of the element" ;
     skos:exactMatch dcterms:title .
 
-schema1:inLanguage a owl:ObjectProperty,
+schema:inLanguage a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "in_language" ;
     rdfs:range linkml:String ;
     skos:editorialNote "Use a string from IETF BCP 47" ;
-    skos:exactMatch schema1:inLanguage .
+    skos:exactMatch schema:inLanguage .
 
 OIO:inSubset a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2672,7 +2915,7 @@ skos:definition a owl:ObjectProperty,
     skos:altLabel "definition" ;
     skos:definition "a description of the element's purpose and use" ;
     skos:exactMatch dcterms:description,
-        schema1:description,
+        schema:description,
         skos:definition .
 
 skos:editorialNote a owl:ObjectProperty,
@@ -2721,26 +2964,57 @@ linkml:EnumDefinition a owl:Class,
     rdfs:label "enum_definition" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:code_set_tag ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:PvFormulaOptions ;
             owl:onProperty linkml:pv_formula ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:ReachabilityQuery ;
+            owl:onProperty linkml:reachable_from ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:code_set ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:code_set_version ],
+            owl:onProperty linkml:code_set_tag ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty linkml:concepts ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousEnumExpression ;
+            owl:onProperty linkml:minus ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:PermissibleValue ;
             owl:onProperty linkml:permissible_values ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:code_set_version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousEnumExpression ;
+            owl:onProperty linkml:include ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:EnumDefinition ;
+            owl:onProperty linkml:inherits ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:MatchQuery ;
+            owl:onProperty linkml:matches ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:code_set ],
-        linkml:Element ;
-    skos:closeMatch qb:HierarchicalCodeList ;
-    skos:definition "List of values that constrain the range of a slot" .
+            owl:onProperty linkml:enum_uri ],
+        linkml:Definition,
+        linkml:EnumExpression ;
+    skos:altLabel "Terminology Value Set",
+        "enum",
+        "term set",
+        "value set" ;
+    skos:closeMatch skos:ConceptScheme ;
+    skos:definition "an element whose instances must be drawn from a specified set of permissible values" ;
+    skos:exactMatch NCIT:C113497,
+        qb:HierarchicalCodeList .
 
 linkml:Extensible a owl:Class,
         linkml:ClassDefinition ;
@@ -2751,6 +3025,79 @@ linkml:Extensible a owl:Class,
         linkml:mixin ;
     skos:definition "mixin for classes that support extension" .
 
+linkml:TypeDefinition a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "type_definition" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_value ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PatternExpression ;
+            owl:onProperty linkml:structured_pattern ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:implicit_prefix ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:base ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:pattern ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:TypeDefinition ;
+            owl:onProperty linkml:union_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousTypeExpression ;
+            owl:onProperty linkml:exactly_one_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousTypeExpression ;
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:TypeDefinition ;
+            owl:onProperty linkml:typeof ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:equals_number ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:uri ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:equals_string ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousTypeExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousTypeExpression ;
+            owl:onProperty linkml:all_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:maximum_value ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:UnitOfMeasure ;
+            owl:onProperty qudt:unit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:equals_string_in ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:repr ],
+        linkml:Element,
+        linkml:TypeExpression ;
+    skos:definition "an element that whose instances are atomic scalar values that can be mapped to primitive types" .
+
 linkml:annotations a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "annotations" ;
@@ -2759,7 +3106,7 @@ linkml:annotations a owl:ObjectProperty,
     rdfs:subPropertyOf linkml:extensions ;
     skos:definition "a collection of tag/text tuples with the semantics of OWL Annotation" .
 
-sh1:order a owl:ObjectProperty,
+sh:order a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "rank" ;
     rdfs:range linkml:Integer ;
@@ -2767,7 +3114,9 @@ sh1:order a owl:ObjectProperty,
         "order",
         "precedence" ;
     skos:definition "the relative order in which the element occurs, lower values are given precedence" ;
-    skos:exactMatch sh1:order ;
+    skos:exactMatch qb:order,
+        qudt:order,
+        sh:order ;
     skos:note "the rank of an element does not affect the semantics" .
 
 skos:altLabel a owl:ObjectProperty,
@@ -2778,11 +3127,11 @@ linkml:AltDescription a owl:Class,
     rdfs:label "alt_description" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:source ;
+            owl:onProperty linkml:description ;
             owl:qualifiedCardinality 1 ],
         [ a owl:Restriction ;
             owl:onClass linkml:String ;
-            owl:onProperty linkml:description ;
+            owl:onProperty linkml:source ;
             owl:qualifiedCardinality 1 ] ;
     skos:definition "an attributed description" .
 
@@ -2814,15 +3163,15 @@ linkml:AnonymousTypeExpression a owl:Class,
             owl:onProperty linkml:equals_number ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:maximum_value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:none_of ],
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:equals_string ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_value ],
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:implicit_prefix ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:equals_string_in ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
@@ -2831,29 +3180,31 @@ linkml:AnonymousTypeExpression a owl:Class,
             owl:allValuesFrom linkml:AnonymousTypeExpression ;
             owl:onProperty linkml:all_of ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:equals_string_in ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousTypeExpression ;
-            owl:onProperty linkml:exactly_one_of ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:PatternExpression ;
             owl:onProperty linkml:structured_pattern ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:equals_string ],
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:maximum_value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousTypeExpression ;
+            owl:onProperty linkml:exactly_one_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousTypeExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_value ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousTypeExpression ;
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:UnitOfMeasure ;
+            owl:onProperty qudt:unit ],
         linkml:TypeExpression .
-
-linkml:Expression a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "expression" ;
-    rdfs:subClassOf linkml:mixin ;
-    skos:definition "general mixin for any class that can represent some form of expression" .
 
 linkml:extensions a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -2861,17 +3212,6 @@ linkml:extensions a owl:ObjectProperty,
     rdfs:domain linkml:Extensible ;
     rdfs:range linkml:Extension ;
     skos:definition "a tag/text tuple attached to an arbitrary element" .
-
-skos:exactMatch a owl:Class,
-        owl:ObjectProperty,
-        linkml:AliasPredicateEnum,
-        linkml:SlotDefinition ;
-    rdfs:label "EXACT_SYNONYM",
-        "exact mappings" ;
-    rdfs:range linkml:Uriorcurie ;
-    rdfs:subPropertyOf skos:mappingRelation ;
-    skos:definition "A list of terms from different schemas or terminology systems that have identical meaning." ;
-    skos:exactMatch skos:exactMatch .
 
 skos:relatedMatch a owl:Class,
         owl:ObjectProperty,
@@ -2897,108 +3237,114 @@ linkml:Example a owl:Class,
             owl:onProperty skos:example ] ;
     skos:definition "usage example and description" .
 
+linkml:Expression a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "expression" ;
+    rdfs:subClassOf linkml:mixin ;
+    skos:definition "general mixin for any class that can represent some form of expression" .
+
 linkml:StructuredAlias a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "structured_alias" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Example ;
+            owl:onProperty linkml:examples ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty dcterms:source ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AliasPredicateEnum ;
+            owl:onProperty rdf:predicate ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
+        [ a owl:Restriction ;
+            owl:onClass linkml:String ;
+            owl:onProperty skosxl:literalForm ;
+            owl:qualifiedCardinality 1 ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty dcterms:title ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
+            owl:onProperty skos:relatedMatch ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:narrowMatch ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:imported_from ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty skos:definition ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AltDescription ;
+            owl:onProperty linkml:alt_descriptions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:altLabel ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:mappingRelation ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty rdfs:seeAlso ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:deprecated ],
-        [ a owl:Restriction ;
-            owl:onClass linkml:String ;
-            owl:onProperty skosxl:literalForm ;
-            owl:qualifiedCardinality 1 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
+            owl:onProperty schema:inLanguage ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Annotation ;
             owl:onProperty linkml:annotations ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AliasPredicateEnum ;
-            owl:onProperty rdf:predicate ],
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:deprecated ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AltDescription ;
-            owl:onProperty linkml:alt_descriptions ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty dcterms:subject ],
         [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty rdfs:seeAlso ],
         [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty dcterms:source ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:exactMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty linkml:todos ],
         [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:broadMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Example ;
-            owl:onProperty linkml:examples ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:editorialNote ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uri ;
             owl:onProperty skos:inScheme ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty skos:definition ],
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty dcterms:subject ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:narrowMatch ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:altLabel ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
+            owl:onProperty skos:closeMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:SubsetDefinition ;
             owl:onProperty OIO:inSubset ],
@@ -3013,7 +3359,18 @@ linkml:SubsetDefinition a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "subset_definition" ;
     rdfs:subClassOf linkml:Element ;
-    skos:definition "the name and description of a subset" .
+    skos:definition "an element that can be used to group other metamodel elements" .
+
+skos:exactMatch a owl:Class,
+        owl:ObjectProperty,
+        linkml:AliasPredicateEnum,
+        linkml:SlotDefinition ;
+    rdfs:label "EXACT_SYNONYM",
+        "exact mappings" ;
+    rdfs:range linkml:Uriorcurie ;
+    rdfs:subPropertyOf skos:mappingRelation ;
+    skos:definition "A list of terms from different schemas or terminology systems that have identical meaning." ;
+    skos:exactMatch skos:exactMatch .
 
 linkml:Extension a owl:Class,
         linkml:ClassDefinition ;
@@ -3023,12 +3380,12 @@ linkml:Extension a owl:Class,
             owl:onProperty linkml:value ;
             owl:qualifiedCardinality 1 ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
+        [ a owl:Restriction ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty linkml:tag ;
-            owl:qualifiedCardinality 1 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ] ;
+            owl:qualifiedCardinality 1 ] ;
     skos:definition "a tag/value pair used to add non-model information to an entry" .
 
 skos:mappingRelation a owl:ObjectProperty,
@@ -3042,6 +3399,51 @@ skos:mappingRelation a owl:ObjectProperty,
     skos:definition "A list of terms from different schemas or terminology systems that have comparable meaning. These may include terms that are precisely equivalent, broader or narrower in meaning, or otherwise semantically related but not equivalent from a strict ontological perspective." ;
     skos:exactMatch skos:mappingRelation .
 
+linkml:EnumExpression a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "enum_expression" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:MatchQuery ;
+            owl:onProperty linkml:matches ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:code_set ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:EnumDefinition ;
+            owl:onProperty linkml:inherits ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:PermissibleValue ;
+            owl:onProperty linkml:permissible_values ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty linkml:concepts ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:code_set_version ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PvFormulaOptions ;
+            owl:onProperty linkml:pv_formula ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousEnumExpression ;
+            owl:onProperty linkml:include ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousEnumExpression ;
+            owl:onProperty linkml:minus ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:ReachabilityQuery ;
+            owl:onProperty linkml:reachable_from ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:code_set_tag ],
+        linkml:Expression ;
+    skos:definition "An expression that constrains the range of a slot" .
+
 linkml:AnonymousSlotExpression a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "anonymous_slot_expression" ;
@@ -3050,79 +3452,12 @@ linkml:AnonymousSlotExpression a owl:Class,
             owl:onClass linkml:Integer ;
             owl:onProperty linkml:maximum_cardinality ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:equals_string_in ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:pattern ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:inlined_as_list ],
+            owl:onClass linkml:PresenceEnum ;
+            owl:onProperty linkml:value_presence ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:AnonymousSlotExpression ;
             owl:onProperty linkml:all_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:all_members ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_value ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:has_member ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:range_expression ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:recommended ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:inlined ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:none_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_cardinality ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:equals_number ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:implicit_prefix ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:PatternExpression ;
-            owl:onProperty linkml:structured_pattern ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:equals_string ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:exactly_one_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:maximum_value ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Element ;
-            owl:onProperty linkml:range ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
@@ -3131,6 +3466,86 @@ linkml:AnonymousSlotExpression a owl:Class,
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Boolean ;
             owl:onProperty linkml:required ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:inlined ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:maximum_value ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:recommended ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:equals_number ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Element ;
+            owl:onProperty linkml:range ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:range_expression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:equals_string_in ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:inlined_as_list ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:UnitOfMeasure ;
+            owl:onProperty qudt:unit ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_value ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PatternExpression ;
+            owl:onProperty linkml:structured_pattern ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_cardinality ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:EnumExpression ;
+            owl:onProperty linkml:enum_range ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:all_members ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:implicit_prefix ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:equals_string ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:pattern ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:has_member ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:exactly_one_of ],
         linkml:AnonymousExpression,
         linkml:SlotExpression .
 
@@ -3139,14 +3554,58 @@ linkml:SchemaDefinition a owl:Class,
     rdfs:label "schema_definition" ;
     rdfs:seeAlso "https://en.wikipedia.org/wiki/Data_dictionary" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Setting ;
-            owl:onProperty linkml:settings ],
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:metamodel_version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SlotDefinition ;
+            owl:onProperty linkml:slots ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:EnumDefinition ;
+            owl:onProperty linkml:enums ],
+        [ a owl:Restriction ;
+            owl:onClass linkml:Ncname ;
+            owl:onProperty rdfs:label ;
+            owl:qualifiedCardinality 1 ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:source_file ],
+        [ a owl:Restriction ;
+            owl:onClass linkml:Uri ;
+            owl:onProperty linkml:id ;
+            owl:qualifiedCardinality 1 ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty pav:version ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty dcterms:license ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty schema:keywords ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Prefix ;
+            owl:onProperty sh:declare ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Datetime ;
+            owl:onProperty linkml:generation_date ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Datetime ;
+            owl:onProperty linkml:source_file_date ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty dcterms:subject ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:ClassDefinition ;
-            owl:onProperty linkml:classes ],
+            owl:allValuesFrom linkml:Setting ;
+            owl:onProperty linkml:settings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SubsetDefinition ;
+            owl:onProperty linkml:subsets ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty linkml:default_curi_maps ],
@@ -3155,76 +3614,58 @@ linkml:SchemaDefinition a owl:Class,
             owl:onClass linkml:String ;
             owl:onProperty linkml:default_prefix ],
         [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:source_file ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty pav:version ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:slots ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SubsetDefinition ;
-            owl:onProperty linkml:subsets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:EnumDefinition ;
-            owl:onProperty linkml:enums ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty schema1:keywords ],
-        [ a owl:Restriction ;
-            owl:onClass linkml:Uri ;
-            owl:onProperty linkml:id ;
-            owl:qualifiedCardinality 1 ],
+            owl:allValuesFrom linkml:TypeDefinition ;
+            owl:onProperty linkml:types ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Ncname ;
             owl:onProperty linkml:emit_prefixes ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Prefix ;
-            owl:onProperty linkml:prefixes ],
+            owl:allValuesFrom linkml:ClassDefinition ;
+            owl:onProperty linkml:classes ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty dcterms:license ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty linkml:imports ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:source_file_size ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:TypeDefinition ;
-            owl:onProperty linkml:types ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Datetime ;
-            owl:onProperty linkml:generation_date ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:metamodel_version ],
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:slot_names_unique ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:TypeDefinition ;
             owl:onProperty linkml:default_range ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:slot_names_unique ],
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:source_file_size ],
         [ a owl:Restriction ;
-            owl:onClass linkml:Ncname ;
-            owl:onProperty rdfs:label ;
-            owl:qualifiedCardinality 1 ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Datetime ;
-            owl:onProperty linkml:source_file_date ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty linkml:imports ],
         linkml:Element ;
     skos:altLabel "data dictionary" ;
+    skos:closeMatch qb:ComponentSet ;
     skos:definition "a collection of subset, type, slot and class definitions" .
+
+linkml:AnonymousClassExpression a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "anonymous_class_expression" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SlotDefinition ;
+            owl:onProperty linkml:slot_conditions ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Definition ;
+            owl:onProperty linkml:is_a ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:exactly_one_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:all_of ],
+        linkml:AnonymousExpression,
+        linkml:ClassExpression .
 
 linkml:Definition a owl:Class,
         linkml:ClassDefinition ;
@@ -3236,12 +3677,12 @@ linkml:Definition a owl:Class,
             owl:onProperty oslc:modifiedBy ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Datetime ;
-            owl:onProperty pav:createdOn ],
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty pav:createdBy ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Definition ;
-            owl:onProperty linkml:is_a ],
+            owl:onClass linkml:Datetime ;
+            owl:onProperty pav:lastUpdatedOn ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Definition ;
             owl:onProperty linkml:mixins ],
@@ -3250,172 +3691,147 @@ linkml:Definition a owl:Class,
             owl:onClass linkml:Boolean ;
             owl:onProperty linkml:abstract ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Definition ;
+            owl:onProperty linkml:apply_to ],
+        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty bibo:status ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Datetime ;
+            owl:onProperty pav:createdOn ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Definition ;
+            owl:onProperty linkml:is_a ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty linkml:string_serialization ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Datetime ;
-            owl:onProperty pav:lastUpdatedOn ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty pav:createdBy ],
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:mixin ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty linkml:values_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Definition ;
-            owl:onProperty linkml:apply_to ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:mixin ],
         linkml:Element ;
-    skos:definition "base class for definitions" .
-
-linkml:AnonymousClassExpression a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "anonymous_class_expression" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Definition ;
-            owl:onProperty linkml:is_a ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:slot_conditions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:all_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:exactly_one_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:none_of ],
-        linkml:AnonymousExpression,
-        linkml:ClassExpression .
+    skos:definition "abstract base class for core metaclasses" .
 
 linkml:Element a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "element" ;
     rdfs:seeAlso "https://en.wikipedia.org/wiki/Data_element" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Extension ;
+            owl:onProperty linkml:extensions ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty sh:order ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty rdfs:label ;
-            owl:qualifiedCardinality 1 ],
+            owl:onProperty schema:inLanguage ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:editorialNote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Annotation ;
+            owl:onProperty linkml:annotations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:note ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:closeMatch ],
+            owl:onProperty skos:broadMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty rdfs:seeAlso ],
+            owl:allValuesFrom linkml:StructuredAlias ;
+            owl:onProperty skosxl:altLabel ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Example ;
+            owl:onProperty linkml:examples ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:LocalName ;
+            owl:onProperty linkml:local_names ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:todos ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty linkml:definition_uri ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:todos ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:StructuredAlias ;
-            owl:onProperty skosxl:altLabel ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty skos:definition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Extension ;
-            owl:onProperty linkml:extensions ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:broadMatch ],
+            owl:onProperty skos:exactMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:narrowMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:LocalName ;
-            owl:onProperty linkml:local_names ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty sh1:order ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty schema1:inLanguage ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AltDescription ;
-            owl:onProperty linkml:alt_descriptions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:relatedMatch ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:altLabel ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uri ;
-            owl:onProperty skos:inScheme ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:editorialNote ],
+            owl:onProperty dcterms:title ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty linkml:deprecated ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Annotation ;
-            owl:onProperty linkml:annotations ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Example ;
-            owl:onProperty linkml:examples ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:imported_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty skos:exactMatch ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty skos:mappingRelation ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
-            owl:onProperty dcterms:title ],
+            owl:onProperty linkml:imported_from ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:SubsetDefinition ;
             owl:onProperty OIO:inSubset ],
         [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:relatedMatch ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Ncname ;
-            owl:onProperty linkml:id_prefixes ],
+            owl:onClass linkml:String ;
+            owl:onProperty rdfs:label ;
+            owl:qualifiedCardinality 1 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty skos:note ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty rdfs:seeAlso ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty skos:closeMatch ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty dcterms:conformsTo ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uri ;
+            owl:onProperty skos:inScheme ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_possible_replacement ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty skos:definition ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty dcterms:source ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty skos:altLabel ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:deprecated_element_has_exact_replacement ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Ncname ;
+            owl:onProperty linkml:id_prefixes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AltDescription ;
+            owl:onProperty linkml:alt_descriptions ],
         linkml:Annotatable,
         linkml:CommonMetadata,
         linkml:Extensible ;
@@ -3427,64 +3843,24 @@ linkml:ClassDefinition a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "class_definition" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:classification_rules ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:exactly_one_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:class_uri ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:UniqueKey ;
-            owl:onProperty linkml:unique_keys ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:slot_names_unique ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:ClassDefinition ;
-            owl:onProperty linkml:union_of ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:slots ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:represents_relationship ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:slot_usage ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:tree_root ],
+            owl:onProperty linkml:slot_conditions ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:ClassDefinition ;
             owl:onProperty linkml:is_a ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:ClassDefinition ;
-            owl:onProperty linkml:disjoint_with ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:slot_conditions ],
+            owl:onProperty linkml:slot_usage ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:ClassDefinition ;
-            owl:onProperty linkml:apply_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:ClassRule ;
-            owl:onProperty sh1:rule ],
+            owl:allValuesFrom linkml:UniqueKey ;
+            owl:onProperty linkml:unique_keys ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:SlotDefinition ;
             owl:onProperty linkml:defining_slots ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:none_of ],
+            owl:onProperty linkml:classification_rules ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Boolean ;
@@ -3493,15 +3869,55 @@ linkml:ClassDefinition a owl:Class,
             owl:allValuesFrom linkml:SlotDefinition ;
             owl:onProperty linkml:attributes ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:all_of ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Uriorcurie ;
             owl:onProperty rdfs:subClassOf ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:all_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:ClassDefinition ;
+            owl:onProperty linkml:apply_to ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:slot_names_unique ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:class_uri ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:represents_relationship ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:tree_root ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SlotDefinition ;
+            owl:onProperty linkml:slots ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:ClassRule ;
+            owl:onProperty sh:rule ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:ClassDefinition ;
+            owl:onProperty linkml:union_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:exactly_one_of ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:ClassDefinition ;
             owl:onProperty linkml:mixins ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:ClassDefinition ;
+            owl:onProperty linkml:disjoint_with ],
         linkml:ClassExpression,
         linkml:Definition ;
     skos:altLabel "message",
@@ -3510,201 +3926,19 @@ linkml:ClassDefinition a owl:Class,
         "table",
         "template" ;
     skos:closeMatch owl:Class ;
-    skos:definition "the definition of a class or interface" .
+    skos:definition "an element whose instances are complex objects that may have slot-value assignments" .
 
 linkml:SlotDefinition a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "slot_definition" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:none_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:role ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Uriorcurie ;
-            owl:onProperty linkml:slot_uri ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:mixins ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:all_members ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_cardinality ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:equals_number ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:SlotDefinition ;
-            owl:onProperty owl:inverseOf ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:SlotDefinition ;
-            owl:onProperty sh1:group ],
-        [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty skos:altLabel ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:ClassDefinition ;
-            owl:onProperty linkml:domain ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:SlotDefinition ;
-            owl:onProperty linkml:reflexive_transitive_form_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty linkml:equals_string_in ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:SlotDefinition ;
-            owl:onProperty linkml:is_a ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:transitive ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:shared ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:implicit_prefix ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:SlotDefinition ;
-            owl:onProperty linkml:transitive_form_of ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:ClassDefinition ;
-            owl:onProperty linkml:domain_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:children_are_mutually_disjoint ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:is_grouping_slot ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:RelationalRoleEnum ;
-            owl:onProperty linkml:relational_role ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Integer ;
             owl:onProperty linkml:maximum_cardinality ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:exactly_one_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:list_elements_ordered ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:designates_type ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:irreflexive ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:inherited ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:maximum_value ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Definition ;
-            owl:onProperty linkml:owner ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:disjoint_with ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:ifabsent ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:PatternExpression ;
-            owl:onProperty linkml:structured_pattern ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty skos:prefLabel ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:pattern ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:any_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Integer ;
-            owl:onProperty linkml:minimum_value ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:key ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:all_of ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:asymmetric ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:equals_expression ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:SlotDefinition ;
-            owl:onProperty linkml:apply_to ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:recommended ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AnonymousClassExpression ;
-            owl:onProperty linkml:range_expression ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:locally_reflexive ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:SlotDefinition ;
-            owl:onProperty rdfs:subPropertyOf ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:usage_slot_name ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:multivalued ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:PathExpression ;
-            owl:onProperty linkml:path_rule ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:identifier ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Boolean ;
@@ -3712,39 +3946,53 @@ linkml:SlotDefinition a owl:Class,
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:inlined ],
+            owl:onProperty linkml:multivalued ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:ClassDefinition ;
+            owl:onProperty linkml:domain_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:usage_slot_name ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:role ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:list_elements_ordered ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:none_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:key ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PresenceEnum ;
+            owl:onProperty linkml:value_presence ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:String ;
             owl:onProperty linkml:equals_string ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:AnonymousSlotExpression ;
-            owl:onProperty linkml:has_member ],
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:maximum_value ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:String ;
-            owl:onProperty linkml:readonly ],
+            owl:onClass linkml:PatternExpression ;
+            owl:onProperty linkml:structured_pattern ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:inlined_as_list ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:is_class_field ],
+            owl:onClass linkml:SlotDefinition ;
+            owl:onProperty rdfs:subPropertyOf ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:reflexive ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:required ],
-        [ a owl:Restriction ;
-            owl:maxQualifiedCardinality 1 ;
-            owl:onClass linkml:Boolean ;
-            owl:onProperty linkml:list_elements_unique ],
+            owl:onProperty linkml:is_grouping_slot ],
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Element ;
@@ -3752,7 +4000,191 @@ linkml:SlotDefinition a owl:Class,
         [ a owl:Restriction ;
             owl:maxQualifiedCardinality 1 ;
             owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:irreflexive ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:PathExpression ;
+            owl:onProperty linkml:path_rule ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SlotDefinition ;
+            owl:onProperty linkml:disjoint_with ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:inlined_as_list ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousClassExpression ;
+            owl:onProperty linkml:range_expression ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:identifier ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:recommended ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:SlotDefinition ;
+            owl:onProperty owl:inverseOf ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:reflexive ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:exactly_one_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:inlined ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:UnitOfMeasure ;
+            owl:onProperty qudt:unit ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:readonly ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
             owl:onProperty linkml:is_usage_slot ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:EnumExpression ;
+            owl:onProperty linkml:enum_range ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SlotDefinition ;
+            owl:onProperty linkml:apply_to ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:SlotDefinition ;
+            owl:onProperty linkml:is_a ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:implicit_prefix ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:required ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:children_are_mutually_disjoint ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:RelationalRoleEnum ;
+            owl:onProperty linkml:relational_role ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:ClassDefinition ;
+            owl:onProperty linkml:domain ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:SlotDefinition ;
+            owl:onProperty sh:group ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:any_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_cardinality ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Uriorcurie ;
+            owl:onProperty linkml:slot_uri ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:transitive ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:inherited ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty linkml:equals_string_in ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:all_members ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:SlotDefinition ;
+            owl:onProperty linkml:transitive_form_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:has_member ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:equals_expression ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:minimum_value ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:list_elements_unique ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:ifabsent ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty linkml:pattern ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:locally_reflexive ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:asymmetric ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:SlotDefinition ;
+            owl:onProperty linkml:reflexive_transitive_form_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Integer ;
+            owl:onProperty linkml:equals_number ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:is_class_field ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:AnonymousSlotExpression ;
+            owl:onProperty linkml:all_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SlotDefinition ;
+            owl:onProperty linkml:mixins ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:designates_type ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Boolean ;
+            owl:onProperty linkml:shared ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:SlotDefinition ;
+            owl:onProperty linkml:union_of ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:Definition ;
+            owl:onProperty linkml:owner ],
+        [ a owl:Restriction ;
+            owl:maxQualifiedCardinality 1 ;
+            owl:onClass linkml:String ;
+            owl:onProperty skos:prefLabel ],
         linkml:Definition,
         linkml:SlotExpression ;
     skos:altLabel "attribute",
@@ -3761,8 +4193,8 @@ linkml:SlotDefinition a owl:Class,
         "property",
         "slot",
         "variable" ;
-    skos:closeMatch rdf:Property ;
-    skos:definition "the definition of a property or a slot" .
-
+    skos:closeMatch qb:ComponentProperty,
+        rdf:Property ;
+    skos:definition "an element that describes how instances are related to other instances" .
 
 

--- a/linkml_model/shex/meta.shex
+++ b/linkml_model/shex/meta.shex
@@ -1,18 +1,17 @@
-# metamodel_version: 1.7.0
-# version: 2.0.0
 BASE <https://w3id.org/linkml/>
-PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX skosxl: <http://www.w3.org/2008/05/skos-xl#>
 PREFIX pav: <http://purl.org/pav/>
 PREFIX oslc: <http://open-services.net/ns/core#>
-PREFIX schema1: <http://schema.org/>
+PREFIX schema: <http://schema.org/>
 PREFIX bibo: <http://purl.org/ontology/bibo/>
-PREFIX sh1: <https://w3id.org/shacl/>
+PREFIX sh: <https://w3id.org/shacl/>
+PREFIX qudt: <http://qudt.org/schema/qudt/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 
@@ -33,6 +32,8 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 <Date> xsd:date
 
 <Datetime> xsd:dateTime
+
+<DateOrDatetime> <DateOrDatetime>
 
 <Uriorcurie> IRI
 
@@ -84,6 +85,25 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
     )
 }
 
+<AnonymousEnumExpression> CLOSED {
+    (  $<AnonymousEnumExpression_tes> (  &<EnumExpression_tes> ;
+          rdf:type [ <EnumExpression> ] ? ;
+          <code_set> @<Uriorcurie> ? ;
+          <code_set_tag> @<String> ? ;
+          <code_set_version> @<String> ? ;
+          <pv_formula> @<PvFormulaOptions> ? ;
+          <permissible_values> @<PermissibleValue> * ;
+          <include> @<AnonymousEnumExpression> * ;
+          <minus> @<AnonymousEnumExpression> * ;
+          <inherits> @<EnumDefinition> * ;
+          <reachable_from> @<ReachabilityQuery> ? ;
+          <matches> @<MatchQuery> ? ;
+          <concepts> @<Uriorcurie> *
+       ) ;
+       rdf:type [ <AnonymousEnumExpression> ] ?
+    )
+}
+
 <AnonymousExpression>  (
     @<AnonymousClassExpression> OR @<AnonymousSlotExpression>
 )
@@ -111,7 +131,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -123,7 +143,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ <AnonymousExpression> ] ?
     )
@@ -136,6 +156,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           rdf:type [ <SlotExpression> ] ? ;
           <range> @<Element> ? ;
           <range_expression> @<AnonymousClassExpression> ? ;
+          <enum_range> @<EnumExpression> ? ;
           <required> @<Boolean> ? ;
           <recommended> @<Boolean> ? ;
           <inlined> @<Boolean> ? ;
@@ -144,7 +165,9 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <maximum_value> @<Integer> ? ;
           <pattern> @<String> ? ;
           <structured_pattern> @<PatternExpression> ? ;
+          qudt:unit @<UnitOfMeasure> ? ;
           <implicit_prefix> @<String> ? ;
+          <value_presence> @<PresenceEnum> ? ;
           <equals_string> @<String> ? ;
           <equals_string_in> @<String> * ;
           <equals_number> @<Integer> ? ;
@@ -152,7 +175,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <minimum_cardinality> @<Integer> ? ;
           <maximum_cardinality> @<Integer> ? ;
           <has_member> @<AnonymousSlotExpression> ? ;
-          <all_members> @<SlotDefinition> * ;
+          <all_members> @<AnonymousSlotExpression> ? ;
           <none_of> @<AnonymousSlotExpression> * ;
           <exactly_one_of> @<AnonymousSlotExpression> * ;
           <any_of> @<AnonymousSlotExpression> * ;
@@ -167,6 +190,8 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           rdf:type [ <TypeExpression> ] ? ;
           <pattern> @<String> ? ;
           <structured_pattern> @<PatternExpression> ? ;
+          qudt:unit @<UnitOfMeasure> ? ;
+          <implicit_prefix> @<String> ? ;
           <equals_string> @<String> ? ;
           <equals_string_in> @<String> * ;
           <equals_number> @<Integer> ? ;
@@ -195,7 +220,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <defining_slots> @<SlotDefinition> * ;
           <tree_root> @<Boolean> ? ;
           <unique_keys> @<UniqueKey> * ;
-          sh1:rule @<ClassRule> * ;
+          sh:rule @<ClassRule> * ;
           <classification_rules> @<AnonymousClassExpression> * ;
           <slot_names_unique> @<Boolean> ? ;
           <represents_relationship> @<Boolean> ? ;
@@ -241,13 +266,13 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           rdf:type [ <Annotatable> ] ? ;
           &<CommonMetadata_tes> ;
           rdf:type [ <CommonMetadata> ] ? ;
-          sh1:condition @<AnonymousClassExpression> ? ;
+          sh:condition @<AnonymousClassExpression> ? ;
           <postconditions> @<AnonymousClassExpression> ? ;
           <elseconditions> @<AnonymousClassExpression> ? ;
           <bidirectional> @<Boolean> ? ;
           <open_world> @<Boolean> ? ;
-          sh1:order @<Integer> ? ;
-          sh1:deactivated @<Boolean> ? ;
+          sh:order @<Integer> ? ;
+          sh:deactivated @<Boolean> ? ;
           <extensions> @<Extension> * ;
           <annotations> @<Annotation> * ;
           skos:definition @<String> ? ;
@@ -262,7 +287,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -292,7 +317,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -304,14 +329,14 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ <CommonMetadata> ] ?
     )
 }
 
 <Definition>  (
-    @<ClassDefinition> OR @<SlotDefinition>
+    @<ClassDefinition> OR @<EnumDefinition> OR @<SlotDefinition>
 )
 
 <Definition_struct> {
@@ -334,7 +359,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 }
 
 <Element>  (
-    @<Definition> OR @<EnumDefinition> OR @<SchemaDefinition> OR @<SubsetDefinition> OR @<TypeDefinition>
+    @<Definition> OR @<SchemaDefinition> OR @<SubsetDefinition> OR @<TypeDefinition>
 )
 
 <Element_struct> {
@@ -362,7 +387,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -374,22 +399,50 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ <Element> ]
     )
 }
 
 <EnumDefinition> CLOSED {
-    (  $<EnumDefinition_tes> (  &<Element_tes> ;
-          rdf:type [ <Element> ] ? ;
+    (  $<EnumDefinition_tes> (  &<Definition_tes> ;
+          rdf:type [ <Definition> ] ? ;
+          &<EnumExpression_tes> ;
+          rdf:type [ <EnumExpression> ] ? ;
+          <enum_uri> @<Uriorcurie> ? ;
           <code_set> @<Uriorcurie> ? ;
           <code_set_tag> @<String> ? ;
           <code_set_version> @<String> ? ;
           <pv_formula> @<PvFormulaOptions> ? ;
-          <permissible_values> @<PermissibleValue> *
+          <permissible_values> @<PermissibleValue> * ;
+          <include> @<AnonymousEnumExpression> * ;
+          <minus> @<AnonymousEnumExpression> * ;
+          <inherits> @<EnumDefinition> * ;
+          <reachable_from> @<ReachabilityQuery> ? ;
+          <matches> @<MatchQuery> ? ;
+          <concepts> @<Uriorcurie> *
        ) ;
        rdf:type [ <EnumDefinition> ]
+    )
+}
+
+<EnumExpression> CLOSED {
+    (  $<EnumExpression_tes> (  &<Expression_tes> ;
+          rdf:type [ <Expression> ] ? ;
+          <code_set> @<Uriorcurie> ? ;
+          <code_set_tag> @<String> ? ;
+          <code_set_version> @<String> ? ;
+          <pv_formula> @<PvFormulaOptions> ? ;
+          <permissible_values> @<PermissibleValue> * ;
+          <include> @<AnonymousEnumExpression> * ;
+          <minus> @<AnonymousEnumExpression> * ;
+          <inherits> @<EnumDefinition> * ;
+          <reachable_from> @<ReachabilityQuery> ? ;
+          <matches> @<MatchQuery> ? ;
+          <concepts> @<Uriorcurie> *
+       ) ;
+       rdf:type [ <EnumExpression> ] ?
     )
 }
 
@@ -402,7 +455,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 }
 
 <Expression>  (
-    @<SlotExpression> OR @<TypeExpression>
+    @<EnumExpression> OR @<SlotExpression> OR @<TypeExpression>
 )
 
 <Expression_struct> {
@@ -452,7 +505,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -464,7 +517,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ <ImportExpression> ] ?
     )
@@ -475,6 +528,14 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:altLabel @<String>
        ) ;
        rdf:type [ <LocalName> ]
+    )
+}
+
+<MatchQuery> CLOSED {
+    (  $<MatchQuery_tes> (  <identifier_pattern> @<String> ? ;
+          <source_ontology> @<Uriorcurie> ?
+       ) ;
+       rdf:type [ <MatchQuery> ] ?
     )
 }
 
@@ -509,7 +570,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -521,7 +582,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ <PathExpression> ] ?
     )
@@ -551,7 +612,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -563,7 +624,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ <PatternExpression> ] ?
     )
@@ -578,6 +639,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           rdf:type [ <CommonMetadata> ] ? ;
           skos:definition @<String> ? ;
           <meaning> @<Uriorcurie> ? ;
+          qudt:unit @<UnitOfMeasure> ? ;
           <mixins> @<PermissibleValue> * ;
           <extensions> @<Extension> * ;
           <annotations> @<Annotation> * ;
@@ -592,7 +654,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -604,17 +666,29 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ <PermissibleValue> ]
     )
 }
 
 <Prefix> CLOSED {
-    (  $<Prefix_tes> (  <prefix_prefix> @<Ncname> ;
-          <prefix_reference> @<Uri>
+    (  $<Prefix_tes> (  sh:prefix @<Ncname> ;
+          sh:namespace @<Uri>
        ) ;
        rdf:type [ <Prefix> ]
+    )
+}
+
+<ReachabilityQuery> CLOSED {
+    (  $<ReachabilityQuery_tes> (  <source_ontology> @<Uriorcurie> ? ;
+          <source_nodes> @<Uriorcurie> * ;
+          <relationship_types> @<Uriorcurie> * ;
+          <is_direct> @<Boolean> ? ;
+          <include_self> @<Boolean> ? ;
+          <traverse_up> @<Boolean> ?
+       ) ;
+       rdf:type [ <ReachabilityQuery> ] ?
     )
 }
 
@@ -625,7 +699,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           pav:version @<String> ? ;
           <imports> @<Uriorcurie> * ;
           dcterms:license @<String> ? ;
-          <prefixes> @<Prefix> * ;
+          sh:declare @<Prefix> * ;
           <emit_prefixes> @<Ncname> * ;
           <default_curi_maps> @<String> * ;
           <default_prefix> @<String> ? ;
@@ -643,7 +717,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <slot_names_unique> @<Boolean> ? ;
           <settings> @<Setting> * ;
           dcterms:subject @<Uriorcurie> * ;
-          schema1:keywords @<String> *
+          schema:keywords @<String> *
        ) ;
        rdf:type [ <SchemaDefinition> ]
     )
@@ -693,15 +767,17 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <is_usage_slot> @<Boolean> ? ;
           <usage_slot_name> @<String> ? ;
           <relational_role> @<RelationalRoleEnum> ? ;
-          sh1:group @<SlotDefinition> ? ;
+          sh:group @<SlotDefinition> ? ;
           <is_grouping_slot> @<Boolean> ? ;
           <path_rule> @<PathExpression> ? ;
           <disjoint_with> @<SlotDefinition> * ;
           <children_are_mutually_disjoint> @<Boolean> ? ;
+          <union_of> @<SlotDefinition> * ;
           <mixins> @<SlotDefinition> * ;
           <apply_to> @<SlotDefinition> * ;
           <range> @<Element> ? ;
           <range_expression> @<AnonymousClassExpression> ? ;
+          <enum_range> @<EnumExpression> ? ;
           <required> @<Boolean> ? ;
           <recommended> @<Boolean> ? ;
           <inlined> @<Boolean> ? ;
@@ -710,7 +786,9 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <maximum_value> @<Integer> ? ;
           <pattern> @<String> ? ;
           <structured_pattern> @<PatternExpression> ? ;
+          qudt:unit @<UnitOfMeasure> ? ;
           <implicit_prefix> @<String> ? ;
+          <value_presence> @<PresenceEnum> ? ;
           <equals_string> @<String> ? ;
           <equals_string_in> @<String> * ;
           <equals_number> @<Integer> ? ;
@@ -718,7 +796,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <minimum_cardinality> @<Integer> ? ;
           <maximum_cardinality> @<Integer> ? ;
           <has_member> @<AnonymousSlotExpression> ? ;
-          <all_members> @<SlotDefinition> * ;
+          <all_members> @<AnonymousSlotExpression> ? ;
           <none_of> @<AnonymousSlotExpression> * ;
           <exactly_one_of> @<AnonymousSlotExpression> * ;
           <any_of> @<AnonymousSlotExpression> * ;
@@ -733,6 +811,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           rdf:type [ <Expression> ] ? ;
           <range> @<Element> ? ;
           <range_expression> @<AnonymousClassExpression> ? ;
+          <enum_range> @<EnumExpression> ? ;
           <required> @<Boolean> ? ;
           <recommended> @<Boolean> ? ;
           <inlined> @<Boolean> ? ;
@@ -741,7 +820,9 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <maximum_value> @<Integer> ? ;
           <pattern> @<String> ? ;
           <structured_pattern> @<PatternExpression> ? ;
+          qudt:unit @<UnitOfMeasure> ? ;
           <implicit_prefix> @<String> ? ;
+          <value_presence> @<PresenceEnum> ? ;
           <equals_string> @<String> ? ;
           <equals_string_in> @<String> * ;
           <equals_number> @<Integer> ? ;
@@ -749,7 +830,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <minimum_cardinality> @<Integer> ? ;
           <maximum_cardinality> @<Integer> ? ;
           <has_member> @<AnonymousSlotExpression> ? ;
-          <all_members> @<SlotDefinition> * ;
+          <all_members> @<AnonymousSlotExpression> ? ;
           <none_of> @<AnonymousSlotExpression> * ;
           <exactly_one_of> @<AnonymousSlotExpression> * ;
           <any_of> @<AnonymousSlotExpression> * ;
@@ -785,7 +866,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -797,7 +878,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ skosxl:Label ] ?
     )
@@ -820,8 +901,11 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           <base> @<String> ? ;
           <uri> @<Uriorcurie> ? ;
           <repr> @<String> ? ;
+          <union_of> @<TypeDefinition> * ;
           <pattern> @<String> ? ;
           <structured_pattern> @<PatternExpression> ? ;
+          qudt:unit @<UnitOfMeasure> ? ;
+          <implicit_prefix> @<String> ? ;
           <equals_string> @<String> ? ;
           <equals_string_in> @<String> * ;
           <equals_number> @<Integer> ? ;
@@ -841,6 +925,8 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           rdf:type [ <Expression> ] ? ;
           <pattern> @<String> ? ;
           <structured_pattern> @<PatternExpression> ? ;
+          qudt:unit @<UnitOfMeasure> ? ;
+          <implicit_prefix> @<String> ? ;
           <equals_string> @<String> ? ;
           <equals_string_in> @<String> * ;
           <equals_number> @<Integer> ? ;
@@ -878,7 +964,7 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:inScheme @<Uri> ? ;
           <imported_from> @<String> ? ;
           dcterms:source @<Uriorcurie> ? ;
-          schema1:inLanguage @<String> ? ;
+          schema:inLanguage @<String> ? ;
           rdfs:seeAlso @<Uriorcurie> * ;
           <deprecated_element_has_exact_replacement> @<Uriorcurie> ? ;
           <deprecated_element_has_possible_replacement> @<Uriorcurie> ? ;
@@ -890,11 +976,22 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
           skos:relatedMatch @<Uriorcurie> * ;
           skos:narrowMatch @<Uriorcurie> * ;
           skos:broadMatch @<Uriorcurie> * ;
-          sh1:order @<Integer> ?
+          sh:order @<Integer> ?
        ) ;
        rdf:type [ <UniqueKey> ]
     )
 }
 
+<UnitOfMeasure> CLOSED {
+    (  $<UnitOfMeasure_tes> (  qudt:symbol @<String> ? ;
+          skos:exactMatch @<Uriorcurie> * ;
+          qudt:ucumCode @<String> ? ;
+          <derivation> @<String> ? ;
+          qudt:hasQuantityKind @<Uriorcurie> ? ;
+          qudt:iec61360Code @<String> ?
+       ) ;
+       rdf:type [ qudt:Unit ] ?
+    )
+}
 
 


### PR DESCRIPTION
I think the reason that the latest Python artifacts were failing when they were brought into `linkml-runtime` is that at some point the `Makefile` in this project was refactored and the `genmeta` flag got dropped from the call to `gen-python`. These changes restore that (via `gen-project`'s `config-file` option) and does a new regen.