### PR TITLE
proposal add jsonpointer path types

### DIFF
--- a/examples/pointer-example.yaml
+++ b/examples/pointer-example.yaml
@@ -1,0 +1,46 @@
+id: https://w3id.org/linkml/examples/pointer-example
+name: pointer-example
+description: pointer-example
+imports:
+- linkml:types
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://w3id.org/linkml/examples/pointer-example/
+default_prefix: ex
+slots:
+  property:
+    examples:
+    - value: '#/address[1]'
+    identifier: true
+    range: jsonpointer
+  source:
+    examples:
+    - value: bazSource
+    range: string
+  id:
+    examples:
+    - value: object1234
+    identifier: true
+    range: string
+  height:
+    multivalued: true
+    range: string
+  width:
+    multivalued: true
+    range: string
+  address:
+    multivalued: true
+    range: string
+classes:
+  Source:
+    slots:
+    - property
+    - source
+  MyObject:
+    slots:
+    - id
+    - source
+    - height
+    - width
+    - address
+

--- a/linkml_model/model/schema/types.yaml
+++ b/linkml_model/model/schema/types.yaml
@@ -155,3 +155,31 @@ types:
     base: NodeIdentifier
     repr: str
     description: A URI, CURIE or BNODE that represents a node in a model.
+
+  jsonpointer:
+    uri: xsd:string
+    base: str
+    repr: str
+    description: >-
+      A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and
+      SHOULD dereference to a valid object within the current instance document when encoded in tree form.
+    conforms_to: https://datatracker.ietf.org/doc/html/rfc6901
+
+  jsonpath:
+    uri: xsd:string
+    base: str
+    repr: str
+    description: >-
+      A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and
+      SHOULD dereference to zero or more valid objects within the current instance document when encoded
+      in tree form.
+    conforms_to: https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html
+
+  sparqlpath:
+    uri: xsd:string
+    base: str
+    repr: str
+    description: >-
+      A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and
+      SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF.
+    conforms_to: https://www.w3.org/TR/sparql11-query/#propertypaths


### PR DESCRIPTION
- Proposal: Add string types for encoding document paths.
- Example for https://github.com/linkml/linkml/issues/1469
