### PR TITLE
Add missing "not" to partial_match slot description

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1963,7 +1963,7 @@ slots:
   partial_match:
     domain: pattern_expression
     range: boolean
-    description: if true then the pattern must match the whole string, as if enclosed in ^...$
+    description: if not true then the pattern must match the whole string, as if enclosed in ^...$
     in_subset:
       - SpecificationSubset
 


### PR DESCRIPTION
Adding a small but important word missing from the `partial_match` slot description 😁 

Related to work for https://github.com/linkml/linkml/issues/1557