### PR TITLE
Remove Mark from author list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ version = "0.0.0"
 description = "Metamodel schema, documentation, and specification for the Linked Open Data Modeling Language (LinkML)"
 license = "MIT"
 authors = [
-    "Chris Mungall <cjmungall@lbl.gov>",
-    "Mark A. Miller <mamillerpa@gmail.com>"
+    "Chris Mungall <cjmungall@lbl.gov>"
 ]
 
 readme = "README.md"


### PR DESCRIPTION
Mark asked to be removed (he probably doesn't want his personal email address shared). It's not clear who should be added. So for now, let's remove Mark and just leave Chris. fixes #1142