### PR TITLE
Update array metamodel and examples

### DIFF
--- a/linkml_model/model/schema/array.yaml
+++ b/linkml_model/model/schema/array.yaml
@@ -1,7 +1,7 @@
 id: https://w3id.org/linkml/lib/arrays
 name: arrays
 title: LinkML Arrays
-description: >- 
+description: >-
   LinkML templates for storing one-dimensional series, two-dimensional arrays,
   and arrays of higher dimensionality.
 
@@ -9,7 +9,7 @@ description: >-
 
   Note that this model is not intended to be imported directly. Instead,
   use `implements` to denote conformance.
-  
+
 status: testing
 # contributors:
 #  - github:rly
@@ -39,13 +39,13 @@ classes:
   DataStructure:
     abstract: true
 
-  Array:
+  NDArray:
     description: >-
       a data structure consisting of a collection of *elements*, each identified by at least one array index tuple.
     abstract: true
     is_a: DataStructure
     slots:
-      - dimensionality
+      - dimensions
       - elements
       - array_linearization_order
     slot_usage:
@@ -55,65 +55,24 @@ classes:
           an ordered sequence of values. The elements also have an *array interpretation*, where each
           element has a unique index which is determined by array_linearization_order
 
-
-  OneDimensionalSeries:
-    is_a: Array
+  DataArray:
     description: >-
-      An array that has one dimension
-    aliases:
+      a data structure containing an NDArray and a set of one-dimensional series that are used to label
+      the elements of the array
+    is_a: DataStructure
+    slots:
       - axis
-      - 1D array
-      - vector
-      - series
-      - row
-    slots:
-      - series_label
-      - length
-      # TODO: consider offset and rate
-    slot_usage:
-      dimensionality:
-        equals_expression: "1"
-    
-  TwoDimensionalArray:
-    is_a: Array
-    description: >-
-      An array that has two dimensions
-    aliases:
-      - table
-      - matrix
-      - grid
-    slots:
-      - axis0
-      - axis1
-    slot_usage:
-      dimensionality:
-        equals_expression: "2"
-      elements:
-        description: >-
-          this will be serialized as one big long list that should be interpreted as a 2D array
+      - array
 
-  ThreeDimensionalArray:
-    is_a: Array
-    description: >-
-      An array that has two dimensions
-    aliases:
-      - 3D array
-    slots:
-      - axis0
-      - axis1
-      - axis2
-    slot_usage:
-      dimensionality:
-        equals_expression: "3"
-
-  OrderedArray:
+  GroupingByArrayOrder:
     mixin: true
     description: >-
       A mixin that describes an array whose elements are mapped from a linear sequence to an array index
       via a specified mapping
-      
+
   ColumnOrderedArray:
     mixin: true
+    is_a: GroupingByArrayOrder
     description: >-
       An array ordering that is column-order
     slots:
@@ -121,9 +80,10 @@ classes:
     slot_usage:
       array_linearization_order:
         equals_string: COLUMN_MAJOR_ARRAY_ORDER
-        
+
   RowOrderedArray:
     mixin: true
+    is_a: GroupingByArrayOrder
     description: >-
       An array ordering that is row-order or generalizations thereof
     slots:
@@ -131,93 +91,36 @@ classes:
     slot_usage:
       array_linearization_order:
         equals_string: ROW_MAJOR_ARRAY_ORDER
-        
-  MultiDimensionalArray:
-    is_a: Array
-    abstract: true
-    description: >-
-      An array that has more than two dimensions
 
-  ObjectAsTuple:
-    comments:
-      - not modeled as an array since this is used as a metaclass
-    implements:
-      - OneDimensionalSeries
-
-  ArrayIndex:
-    is_a: ObjectAsTuple
-
-  Operation:
-    abstract: true
-    description: >-
-      Represents the transformation of one or more inputs to one or more outputs determined by
-      zero to many operation parameters
-    slots:
-      - specified_input
-      - specified_output
-      - operation_parameters
-
-  ArrayIndexOperation:
-    description: >-
-      An operation that takes as input an Array and is parameterized by an array index tuple and
-      yields an array element
-    slot_usage:
-      specified_input:
-        range: Array
-        maximum_cardinality: 1
-      specified_output:
-        range: Any
-        maximum_cardinality: 1
-      operation_parameters:
-        range: ArrayIndex
-        maximum_cardinality: 1
-      
 slots:
-  dimensionality:
+  dimensions:
     description: >-
       The number of elements in the tuple used to access elements of an array
     aliases:
       - rank
-      - dimension
+      - dimensionality
       - number of axes
       - number of elements
     range: integer
   axis:
-    abstract: true
-    range: OneDimensionalSeries
+    range: NDArray
+    slot_usage:
+      dimensions:
+        equals_number: 1
     aliases:
       - dimension
     description: >-
-      A one dimensional series that contains elements that form one part of a tuple used to access an array
-  axis0:
-    is_a: axis
-    aliases:
-      - dimension0
+      A one-dimensional series that contains elements that form one part of a tuple used to access an array
+    required: true
+  axis_index:
+    range: integer
     description: >-
-      An axis that is the zeroth index of the tuple used to access an array
-    range: OneDimensionalSeries
-    rank: 0
-    required: true
-    inlined: true
-    inlined_as_list: true
-  axis1:
-    is_a: axis
+      The position of an axis in a tuple used to access an array
+  array:
+    range: NDArray
     description: >-
-      An axis that is the index after the zeroth of the tuple used to access an array
-    range: OneDimensionalSeries
-    rank: 1
+      An array that is labeled by a set of one-dimensional series
     required: true
-    inlined: true
-    inlined_as_list: true
-  axis2:
-    is_a: axis
-    aliases:
-      - z
-    range: OneDimensionalSeries
-    rank: 2
-    required: true
-    inlined: true
-    inlined_as_list: true
   elements:
     # this will be serialized as one big long list that should be interpreted as a 2D array
     range: Any
@@ -251,7 +154,7 @@ slots:
   operation_parameters:
     range: Any
     multivalued: true
-  
+
 enums:
   ArrayLinearizationOrderOptions:
     description: >-
@@ -273,4 +176,4 @@ enums:
         aliases:
           - C order
 
-        
+

--- a/linkml_model/model/schema/array.yaml
+++ b/linkml_model/model/schema/array.yaml
@@ -175,5 +175,3 @@ enums:
           or any generalization thereof to dimensionality greater than 2
         aliases:
           - C order
-
-

--- a/tests/input/examples/schema_definition-array-1.yaml
+++ b/tests/input/examples/schema_definition-array-1.yaml
@@ -1,0 +1,118 @@
+id: https://example.org/arrays
+name: arrays-temperature-example
+title: Array Temperature Example
+description: |-
+  Example LinkML schema to demonstrate a 3D DataArray of temperature values with labeled axes
+license: MIT
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  wgs84: http://www.w3.org/2003/01/geo/wgs84_pos#
+  example: https://example.org/
+
+default_prefix: example
+
+imports:
+  - linkml:types
+
+classes:
+
+  TemperatureDataset:
+    tree_root: true
+    implements:
+      - linkml:DataArray
+    attributes:
+      name:
+        identifier: true
+        range: string
+      latitude_in_deg:
+        implements:
+          - linkml:axis
+        range: LatitudeSeries
+        required: true
+        annotations:
+          axis_index: 0
+      longitude_in_deg:
+        implements:
+          - linkml:axis
+        range: LongitudeSeries
+        required: true
+        annotations:
+          axis_index: 1
+      time_in_d:
+        implements:
+          - linkml:axis
+        range: DaySeries
+        required: true
+        annotations:
+          axis_index: 2
+      temperatures_in_K:
+        implements:
+          - linkml:array
+        range: TemperatureMatrix
+        required: true
+
+  TemperatureMatrix:
+    description: A 3D array of temperatures
+    implements:
+      - linkml:NDArray
+      - linkml:RowOrderedArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: K
+    annotations:
+      dimensions: 3
+
+  LatitudeSeries:
+    description: A series whose values represent latitude
+    implements:
+      - linkml:NDArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: deg
+    annotations:
+      dimensions: 1
+
+  LongitudeSeries:
+    description: A series whose values represent longitude
+    implements:
+      - linkml:NDArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: deg
+    annotations:
+      dimensions: 1
+
+  DaySeries:
+    description: A series whose values represent the days since the start of the measurement period
+    implements:
+      - linkml:NDArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: d
+    annotations:
+      dimensions: 1

--- a/tests/input/examples/schema_definition-array-2.yaml
+++ b/tests/input/examples/schema_definition-array-2.yaml
@@ -24,13 +24,15 @@ classes:
 
   TimestampSeries:
     implements:
-      - linkml:OneDimensionalSeries
+      - linkml:NDArray
+    annotations:
+      dimensions: 1
     # TODO abstract from children
 
   IrregularlySampledTimestampSeries:
     is_a: TimestampSeries
     implements:
-      - linkml:OneDimensionalSeries
+      - linkml:NDArray
     attributes:
       name:  # the row label
         key: true  # unique when nested (unlike identifier, which is a global identifier)
@@ -44,11 +46,13 @@ classes:
           - linkml:elements
         unit:
           ucum_code: s
+    annotations:
+      dimensions: 1
 
   RegularlySampledTimestampSeries:
     is_a: TimestampSeries
     implements:
-      - linkml:OneDimensionalSeries
+      - linkml:NDArray
     attributes:
       name:  # the row label
         key: true  # unique when nested (unlike identifier, which is a global identifier)
@@ -77,6 +81,8 @@ classes:
           - linkml:elements
         unit:
           ucum_code: s
+    annotations:
+      dimensions: 1
 
   Electrode:
     attributes:
@@ -90,54 +96,89 @@ classes:
 
   ElectrodeSeries:
     implements:
-      - linkml:OneDimensionalSeries
+      - linkml:NDArray
     attributes:
-      name:  # the row label
-        key: true  # unique when nested (unlike identifier, which is a global identifier)
-        implements:
-          - linkml:name
       values:
         range: Electrode
         multivalued: true
         required: true
-        inlined: true  # not needed if value is not an object
-        inlined_as_list: true
+        # this will be serialized as an array of string keys/identifiers of the electrodes
         implements:
           - linkml:elements
+    annotations:
+      dimensions: 1
 
-  ElectricalArray:
+  ElectricalDataMatrix:
+    description: >-
+      A 2D array of electrode voltage measurements over time.
+      See ElectricalDataArray for its usage with axes labels.
     implements:
-      - linkml:TwoDimensionalArray
+      - linkml:NDArray
+      - linkml:RowOrderedArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: V
+    annotations:
+      dimensions: 3
+
+  ElectricalDataArray:
+    implements:
+      - linkml:DataArray
     attributes:
       time:
         range: TimestampSeries  # abstract - could be IrregularlySampled... or RegularlySampled...
         required: true
         implements:
-          - linkml:axis0
+          - linkml:axis
         inlined: true
+        annotations:
+          axis_index: 0
       electrode:
         range: ElectrodeSeries
         required: true
         implements:
-          - linkml:axis1
+          - linkml:axis
         inlined: true
+        annotations:
+          axis_index: 1
       values:
-        range: float
-        multivalued: true
+        range: ElectricalDataMatrix
         required: true
-        unit:
-          ucum_code: V
+        inlined: true
         implements:
-          - linkml:elements
+          - linkml:array
+    annotations:
+      dimensions: 2
 
-  IrregularlySampledElectricalArray:
-    is_a: ElectricalArray
+  IrregularlySampledElectricalDataArray:
+    is_a: ElectricalDataArray
     slot_usage:
       time:
         range: IrregularlySampledTimestampSeries
+    annotations:
+      dimensions: 2
 
-  RegularlySampledElectricalArray:
-    is_a: ElectricalArray
+  RegularlySampledElectricalDataArray:
+    is_a: ElectricalDataArray
     attributes:
       time:
         range: RegularlySampledTimestampSeries
+    annotations:
+      dimensions: 2
+
+  File:
+    tree_root: true
+    attributes:
+      electrical_data_arrays:
+        range: ElectricalDataArray  # inlined by default
+        multivalued: true
+      electrodes:
+        range: Electrode
+        multivalued: true
+        inlined_as_list: true


### PR DESCRIPTION
- Changed `OneDimensionalSeries`, `TwoDimensionalArray`, etc. to `NDArray`.
- Added `DataArray` which is analogous to [xarray's DataArray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html)
- Renamed slot "dimensionality" -> "dimensions"
- Renamed "OrderedArray" -> "GroupingByArrayOrder"