### PR TITLE
Make maximum_value and minimum_value accept linkml:Any

### DIFF
--- a/linkml_model/model/docs/specification/03schemas.md
+++ b/linkml_model/model/docs/specification/03schemas.md
@@ -352,8 +352,8 @@ Any instance *s* of a SlotDefinition may have assignments in any of the followin
 | [range](../range.md) | 0..1 <br/> [Element](../Element.md)  | defines the type of the object of the slot   |
 | [range_expression](../range_expression.md) | 0..1 <br/> [AnonymousClassExpression](../AnonymousClassExpression.md)  | A range that is described as a boolean expression combining existing ranges  |
 | [enum_range](../enum_range.md) | 0..1 <br/> [EnumExpression](../EnumExpression.md)  | An inlined enumeration   |
-| [minimum_value](../minimum_value.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)  | for slots with ranges of type number, the value must be equal to or higher th... |
-| [maximum_value](../maximum_value.md) | 0..1 <br/> [xsd:integer](http://www.w3.org/2001/XMLSchema#integer)  | for slots with ranges of type number, the value must be equal to or lowe than... |
+| [minimum_value](../minimum_value.md) | 0..1 <br/> [linkml:Any](https://linkml.io/linkml-model/latest/docs/Anything/)  | for slots with ordinal ranges, the value must be equal to or higher th... |
+| [maximum_value](../maximum_value.md) | 0..1 <br/> [linkml:Any](https://linkml.io/linkml-model/latest/docs/Anything/)  | for slots with ordinal ranges, the value must be equal to or lowe than... |
 | [structured_pattern](../structured_pattern.md) | 0..1 <br/> [PatternExpression](../PatternExpression.md)  | the string value of the slot must conform to the regular expression in the pa... |
 | [implicit_prefix](../implicit_prefix.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string)  | Causes the slot value to be interpreted as a uriorcurie after prefixing with ... |
 | [equals_string](../equals_string.md) | 0..1 <br/> [xsd:string](http://www.w3.org/2001/XMLSchema#string)  | the slot must have range string and the value of the slot must equal the spec... |

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1935,8 +1935,10 @@ slots:
     aliases:
       - low value
     domain: slot_definition
-    range: integer
-    description: for slots with ranges of type number, the value must be equal to or higher than this
+    range: Anything
+    description: For ordinal ranges, the value must be equal to or higher than this
+    notes:
+      - Range to be refined to an "Ordinal" metaclass - see https://github.com/linkml/linkml/issues/1384#issuecomment-1892721142
     inherited: true
     in_subset:
       - SpecificationSubset
@@ -1946,8 +1948,10 @@ slots:
     aliases:
       - high value
     domain: slot_definition
-    range: integer
-    description: for slots with ranges of type number, the value must be equal to or lowe than this
+    range: Anything
+    description: For ordinal ranges, the value must be equal to or lower than this
+    notes:
+      - Range to be refined to an "Ordinal" metaclass - see https://github.com/linkml/linkml/issues/1384#issuecomment-1892721142
     inherited: true
     in_subset:
       - SpecificationSubset


### PR DESCRIPTION
Fix: https://github.com/linkml/linkml/issues/1384

Per the discussion on 1384, Relax the range constraint on `minimum_value` and `maximum_value` to accept `linkml:Any`, pending a fuller rework to create an `Ordinal` meta-type. 

Changes
- Updated `range: Anything`
- Updated slot descriptions to anticipate ordinal type - I figured this would be easier than trying to say "For now you can put anything here, but in the future..." 
- Add `notes` to remind about future plans
- Update docs to match.

I tried running `gen-project` but it seemed to not just change the `minimum_value` and `maximum_value`, but rework most of the generated schema, so I held off adding that to the PR - not sure how that typically works in PRs for this repo. lmk if i should include.