### PR TITLE
Add missing oslc and bibo prefixes

### DIFF
--- a/linkml_model/model/schema/datasets.yaml
+++ b/linkml_model/model/schema/datasets.yaml
@@ -21,6 +21,8 @@ prefixes:
   csvw: http://www.w3.org/ns/csvw#
   dcat: http://www.w3.org/ns/dcat#
   mediatypes: https://www.iana.org/assignments/media-types/
+  oslc: http://open-services.net/ns/core#
+  bibo: http://purl.org/ontology/bibo/
 
 default_prefix: datasets
 default_range: string


### PR DESCRIPTION
While running `gen-project` on my previous PR (unlinked because they're not really related), I noticed these warnings:

```
WARNING:root:File "datasets.yaml", line 259, col 15: Unrecognized prefix: oslc
WARNING:root:File "datasets.yaml", line 264, col 15: Unrecognized prefix: bibo
```

And true enough, these prefixes were not present, so I went ahead and added them. Both links dereference correctly so their accuracy can be confirmed :)

