### PR TITLE
First pass at native NDArray support.

### DIFF
--- a/linkml_model/model/schema/array.yaml
+++ b/linkml_model/model/schema/array.yaml
@@ -63,6 +63,8 @@ classes:
     slots:
       - axis
       - array
+    see_also:
+      - https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html
 
   GroupingByArrayOrder:
     mixin: true

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1570,7 +1570,7 @@ slots:
     inherited: true
     description: the exact number of entries for a multivalued slot
     in_subset:
-      - SpecificationSubse
+      - SpecificationSubset
     comments:
       - if exact_cardinality is set, then minimum_cardinalty and maximum_cardinality must be unset or have the same value
 

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1427,10 +1427,10 @@ slots:
     description: coerces the value of the slot into an array and defines the dimensions of that array
     status: testing
 
-  array_axes:
+  dimensions:
     description: definitions of each axis in the array
     domain: array_info_expression
-    range: array_axis_expression
+    range: dimension_expression
     multivalued: true
     inlined: true
     status: testing
@@ -2970,10 +2970,10 @@ classes:
       - exact_dimensions
       - minimum_dimensions
       - maximum_dimensions
-      - array_axes
+      - dimensions
     status: testing
 
-  array_axis_expression:
+  dimension_expression:
     description: defines one of the dimensions of an array
     mixins:
       - extensible

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1419,36 +1419,48 @@ slots:
       - BasicSubset
       - ObjectOrientedProfile
 
-  array_info:
+  array:
     domain: slot_definition
-    range: array_info_expression
+    range: array_expression
     inherited: true
     description: coerces the value of the slot into an array and defines the dimensions of that array
     status: testing
 
-  dimensions_info:
+  dimensions:
+    aliases:
+      - dimensions
     description: definitions of each axis in the array
-    domain: array_info_expression
+    domain: array_expression
     range: dimension_expression
     multivalued: true
+    list_elements_ordered: true
     status: testing
 
   minimum_dimensions:
     description: minimum number of dimensions in the array
-    domain: array_info_expression
+    domain: array_expression
     range: integer
     status: testing
+    minimum_value: 1
 
   maximum_dimensions:
     description: maximum number of dimensions in the array
-    domain: array_info_expression
+    domain: array_expression
     range: integer
     status: testing
+    minimum_value: 1
 
   exact_dimensions:
     description: exact number of dimensions in the array
-    domain: array_info_expression
+    domain: array_expression
     range: integer
+    status: testing
+    minimum_value: 1
+
+  has_extra_dimensions:
+    description: If this is set to true
+    domain: array_expression
+    range: boolean
     status: testing
 
   inherited:
@@ -1558,7 +1570,9 @@ slots:
     inherited: true
     description: the exact number of entries for a multivalued slot
     in_subset:
-      - SpecificationSubset
+      - SpecificationSubse
+    comments:
+      - if exact_cardinality is set, then minimum_cardinalty and maximum_cardinality must be unset or have the same value
 
   minimum_cardinality:
     is_a: list_value_specification_constant
@@ -1567,6 +1581,7 @@ slots:
     description: the minimum number of entries for a multivalued slot
     in_subset:
       - SpecificationSubset
+    minimum_value: 0
 
   maximum_cardinality:
     is_a: list_value_specification_constant
@@ -1575,6 +1590,9 @@ slots:
     description: the maximum number of entries for a multivalued slot
     in_subset:
       - SpecificationSubset
+    comments:
+      - maximum_cardinality cannot be less than minimum_cardinality
+    minimum_value: 0
 
   equals_string_in:
     is_a: list_value_specification_constant
@@ -2799,7 +2817,7 @@ classes:
       - domain
       - slot_uri
       - multivalued
-      - array_info
+      - array
       - inherited
       - readonly
       - ifabsent
@@ -2958,7 +2976,7 @@ classes:
     in_subset:
       - SpecificationSubset
 
-  array_info_expression:
+  array_expression:
     description: defines the dimensions of an array
     mixins:
       - extensible
@@ -2968,7 +2986,8 @@ classes:
       - exact_dimensions
       - minimum_dimensions
       - maximum_dimensions
-      - dimensions_info
+      - has_extra_dimensions
+      - dimensions
     status: testing
 
   dimension_expression:

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1442,6 +1442,8 @@ slots:
     range: integer
     status: testing
     # minimum_value: 1
+    comments:
+      - minimum_cardinality cannot be greater than maximum_cardinality
 
   maximum_number_dimensions:
     description: maximum number of dimensions in the array, or False if explicitly no maximum.
@@ -1464,6 +1466,8 @@ slots:
     range: integer
     status: testing
     # minimum_value: 1
+    comments:
+      - if exact_number_dimensions is set, then minimum_number_dimensions and maximum_number_dimensions must be unset or have the same value
 
   has_extra_dimensions:
     description: If this is set to true
@@ -1590,6 +1594,8 @@ slots:
     in_subset:
       - SpecificationSubset
     # minimum_value: 0
+    comments:
+      - minimum_cardinality cannot be greater than maximum_cardinality
 
   maximum_cardinality:
     is_a: list_value_specification_constant

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1420,6 +1420,34 @@ slots:
       - BasicSubset
       - ObjectOrientedProfile
 
+  array_shape:
+    domain: slot_definition
+    range: array_shape_expression
+    inherited: true
+    description: coerces the value of the slot into an array and defines the dimensions of that array
+
+  array_axes:
+    description: definitions of each axis in the array
+    domain: array_shape_expression
+    range: array_axis_expression
+    multivalued: true
+    inlined: true
+
+  minimum_dimensions:
+    description: minimum number of dimensions in the array
+    domain: array_shape_expression
+    range: integer
+
+  maximum_dimensions:
+    description: maximum number of dimensions in the array
+    domain: array_shape_expression
+    range: integer
+
+  exact_dimensions:
+    description: exact number of dimensions in the array
+    domain: array_shape_expression
+    range: integer
+
   inherited:
     domain: slot_definition
     range: boolean
@@ -1518,6 +1546,14 @@ slots:
     see_also:
       - https://linkml.io/linkml/developers/inference.html
       - https://linkml.io/linkml/schemas/advanced.html#equals-expression
+    in_subset:
+      - SpecificationSubset
+
+  exact_cardinality:
+    is_a: list_value_specification_constant
+    range: integer
+    inherited: true
+    description: the exact number of entries for a multivalued slot
     in_subset:
       - SpecificationSubset
 
@@ -2715,6 +2751,7 @@ classes:
       - equals_string_in
       - equals_number
       - equals_expression
+      - exact_cardinality
       - minimum_cardinality
       - maximum_cardinality
       - has_member
@@ -2759,6 +2796,7 @@ classes:
       - domain
       - slot_uri
       - multivalued
+      - array_shape
       - inherited
       - readonly
       - ifabsent
@@ -2916,6 +2954,33 @@ classes:
       - swrl:Imp
     in_subset:
       - SpecificationSubset
+
+  array_shape_expression:
+    description: defines the dimensions of an array
+    mixins:
+      - extensible
+      - annotatable
+      - common_metadata
+    slots:
+      - exact_dimensions
+      - minimum_dimensions
+      - maximum_dimensions
+      - array_axes
+
+  array_axis_expression:
+    description: defines one of the dimensions of an array
+    mixins:
+      - extensible
+      - annotatable
+      - common_metadata
+    slots:
+      - name
+      - rank
+      - equals_expression
+      - alias
+      - maximum_cardinality
+      - minimum_cardinality
+      - exact_cardinality
 
   pattern_expression:
     description: a regular expression pattern used to evaluate conformance of a string

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1452,9 +1452,11 @@ slots:
     range: Anything
     any_of:
       - range: integer
-        # minimum_value: 0
+        # minimum_value: 1
       - range: boolean
     status: testing
+    comments:
+      - maximum_number_dimensions cannot be less than minimum_number_dimensions
 
   exact_number_dimensions:
     description: exact number of dimensions in the array

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1444,11 +1444,17 @@ slots:
     minimum_value: 1
 
   maximum_number_dimensions:
-    description: maximum number of dimensions in the array
+    description: maximum number of dimensions in the array, or False if explicitly no maximum.
+      If this is unset, and an explicit list of dimensions are passed using dimensions, then this is interpreted
+      as a closed list and the maximum_number_dimensions is the length of the dimensions list, unless this
+      value is set to False
     domain: array_expression
-    range: integer
+    range: Anything
+    any_of:
+      - range: integer
+        minimum_value: 0
+      - range: boolean
     status: testing
-    minimum_value: 1
 
   exact_number_dimensions:
     description: exact number of dimensions in the array
@@ -2998,7 +3004,6 @@ classes:
       - common_metadata
     slots:
       - alias
-      - equals_expression
       - maximum_cardinality
       - minimum_cardinality
       - exact_cardinality

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1441,7 +1441,7 @@ slots:
     domain: array_expression
     range: integer
     status: testing
-    minimum_value: 1
+    # minimum_value: 1
 
   maximum_number_dimensions:
     description: maximum number of dimensions in the array, or False if explicitly no maximum.
@@ -1452,7 +1452,7 @@ slots:
     range: Anything
     any_of:
       - range: integer
-        minimum_value: 0
+        # minimum_value: 0
       - range: boolean
     status: testing
 
@@ -1461,7 +1461,7 @@ slots:
     domain: array_expression
     range: integer
     status: testing
-    minimum_value: 1
+    # minimum_value: 1
 
   has_extra_dimensions:
     description: If this is set to true
@@ -1587,7 +1587,7 @@ slots:
     description: the minimum number of entries for a multivalued slot
     in_subset:
       - SpecificationSubset
-    minimum_value: 0
+    # minimum_value: 0
 
   maximum_cardinality:
     is_a: list_value_specification_constant
@@ -1598,7 +1598,7 @@ slots:
       - SpecificationSubset
     comments:
       - maximum_cardinality cannot be less than minimum_cardinality
-    minimum_value: 0
+    # minimum_value: 0
 
   equals_string_in:
     is_a: list_value_specification_constant

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1436,21 +1436,21 @@ slots:
     list_elements_ordered: true
     status: testing
 
-  minimum_dimensions:
+  minimum_number_dimensions:
     description: minimum number of dimensions in the array
     domain: array_expression
     range: integer
     status: testing
     minimum_value: 1
 
-  maximum_dimensions:
+  maximum_number_dimensions:
     description: maximum number of dimensions in the array
     domain: array_expression
     range: integer
     status: testing
     minimum_value: 1
 
-  exact_dimensions:
+  exact_number_dimensions:
     description: exact number of dimensions in the array
     domain: array_expression
     range: integer
@@ -2983,9 +2983,9 @@ classes:
       - annotatable
       - common_metadata
     slots:
-      - exact_dimensions
-      - minimum_dimensions
-      - maximum_dimensions
+      - exact_number_dimensions
+      - minimum_number_dimensions
+      - maximum_number_dimensions
       - has_extra_dimensions
       - dimensions
     status: testing

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1425,6 +1425,7 @@ slots:
     range: array_info_expression
     inherited: true
     description: coerces the value of the slot into an array and defines the dimensions of that array
+    status: testing
 
   array_axes:
     description: definitions of each axis in the array
@@ -1432,21 +1433,25 @@ slots:
     range: array_axis_expression
     multivalued: true
     inlined: true
+    status: testing
 
   minimum_dimensions:
     description: minimum number of dimensions in the array
     domain: array_info_expression
     range: integer
+    status: testing
 
   maximum_dimensions:
     description: maximum number of dimensions in the array
     domain: array_info_expression
     range: integer
+    status: testing
 
   exact_dimensions:
     description: exact number of dimensions in the array
     domain: array_info_expression
     range: integer
+    status: testing
 
   inherited:
     domain: slot_definition
@@ -2966,6 +2971,7 @@ classes:
       - minimum_dimensions
       - maximum_dimensions
       - array_axes
+    status: testing
 
   array_axis_expression:
     description: defines one of the dimensions of an array
@@ -2981,6 +2987,7 @@ classes:
       - maximum_cardinality
       - minimum_cardinality
       - exact_cardinality
+    status: testing
 
   pattern_expression:
     description: a regular expression pattern used to evaluate conformance of a string

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -30,7 +30,6 @@ description: |-
   [https://w3id.org/linkml/is_a](https://w3id.org/linkml/is_a)
 
 license: https://creativecommons.org/publicdomain/zero/1.0/
-version: 2.0.0
 
 prefixes:
   linkml: https://w3id.org/linkml/
@@ -1432,7 +1431,6 @@ slots:
     domain: array_info_expression
     range: dimension_expression
     multivalued: true
-    inlined: true
     status: testing
 
   minimum_dimensions:
@@ -2980,10 +2978,8 @@ classes:
       - annotatable
       - common_metadata
     slots:
-      - name
-      - rank
-      - equals_expression
       - alias
+      - equals_expression
       - maximum_cardinality
       - minimum_cardinality
       - exact_cardinality

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1428,7 +1428,7 @@ slots:
 
   dimensions:
     aliases:
-      - dimensions
+      - axes
     description: definitions of each axis in the array
     domain: array_expression
     range: dimension_expression

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1420,32 +1420,32 @@ slots:
       - BasicSubset
       - ObjectOrientedProfile
 
-  array_shape:
+  array_info:
     domain: slot_definition
-    range: array_shape_expression
+    range: array_info_expression
     inherited: true
     description: coerces the value of the slot into an array and defines the dimensions of that array
 
   array_axes:
     description: definitions of each axis in the array
-    domain: array_shape_expression
+    domain: array_info_expression
     range: array_axis_expression
     multivalued: true
     inlined: true
 
   minimum_dimensions:
     description: minimum number of dimensions in the array
-    domain: array_shape_expression
+    domain: array_info_expression
     range: integer
 
   maximum_dimensions:
     description: maximum number of dimensions in the array
-    domain: array_shape_expression
+    domain: array_info_expression
     range: integer
 
   exact_dimensions:
     description: exact number of dimensions in the array
-    domain: array_shape_expression
+    domain: array_info_expression
     range: integer
 
   inherited:
@@ -2796,7 +2796,7 @@ classes:
       - domain
       - slot_uri
       - multivalued
-      - array_shape
+      - array_info
       - inherited
       - readonly
       - ifabsent
@@ -2955,7 +2955,7 @@ classes:
     in_subset:
       - SpecificationSubset
 
-  array_shape_expression:
+  array_info_expression:
     description: defines the dimensions of an array
     mixins:
       - extensible

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1427,7 +1427,7 @@ slots:
     description: coerces the value of the slot into an array and defines the dimensions of that array
     status: testing
 
-  dimensions:
+  dimensions_info:
     description: definitions of each axis in the array
     domain: array_info_expression
     range: dimension_expression
@@ -2970,7 +2970,7 @@ classes:
       - exact_dimensions
       - minimum_dimensions
       - maximum_dimensions
-      - dimensions
+      - dimensions_info
     status: testing
 
   dimension_expression:

--- a/linkml_model/model/schema/types.yaml
+++ b/linkml_model/model/schema/types.yaml
@@ -4,7 +4,6 @@ id: https://w3id.org/linkml/types
 
 description: Shared type definitions for the core LinkML mode and metamodel
 license: https://creativecommons.org/publicdomain/zero/1.0/
-version: 2.0.0
 
 prefixes:
   linkml: https://w3id.org/linkml/

--- a/tests/input/examples/schema_definition-array-2.yaml
+++ b/tests/input/examples/schema_definition-array-2.yaml
@@ -26,7 +26,7 @@ classes:
     implements:
       - linkml:NDArray
     annotations:
-      dimensions: "1"
+      dimensions_info: "1"
     # TODO abstract from children
 
   IrregularlySampledTimestampSeries:
@@ -47,7 +47,7 @@ classes:
         unit:
           ucum_code: s
     annotations:
-      dimensions: "1"
+      dimensions_info: "1"
 
   RegularlySampledTimestampSeries:
     is_a: TimestampSeries
@@ -82,7 +82,7 @@ classes:
         unit:
           ucum_code: s
     annotations:
-      dimensions: "1"
+      dimensions_info: "1"
 
   Electrode:
     attributes:
@@ -106,7 +106,7 @@ classes:
         implements:
           - linkml:elements
     annotations:
-      dimensions: "1"
+      dimensions_info: "1"
 
   ElectricalDataMatrix:
     description: >-
@@ -125,7 +125,7 @@ classes:
         unit:
           ucum_code: V
     annotations:
-      dimensions: 3
+      dimensions_info: 3
 
   ElectricalDataArray:
     implements:
@@ -154,7 +154,7 @@ classes:
         implements:
           - linkml:array
     annotations:
-      dimensions: 2
+      dimensions_info: 2
 
   IrregularlySampledElectricalDataArray:
     is_a: ElectricalDataArray
@@ -162,7 +162,7 @@ classes:
       time:
         range: IrregularlySampledTimestampSeries
     annotations:
-      dimensions: 2
+      dimensions_info: 2
 
   RegularlySampledElectricalDataArray:
     is_a: ElectricalDataArray
@@ -170,7 +170,7 @@ classes:
       time:
         range: RegularlySampledTimestampSeries
     annotations:
-      dimensions: 2
+      dimensions_info: 2
 
   File:
     tree_root: true

--- a/tests/input/examples/schema_definition-array-2.yaml
+++ b/tests/input/examples/schema_definition-array-2.yaml
@@ -26,7 +26,7 @@ classes:
     implements:
       - linkml:NDArray
     annotations:
-      dimensions: 1
+      dimensions: "1"
     # TODO abstract from children
 
   IrregularlySampledTimestampSeries:
@@ -47,7 +47,7 @@ classes:
         unit:
           ucum_code: s
     annotations:
-      dimensions: 1
+      dimensions: "1"
 
   RegularlySampledTimestampSeries:
     is_a: TimestampSeries
@@ -82,7 +82,7 @@ classes:
         unit:
           ucum_code: s
     annotations:
-      dimensions: 1
+      dimensions: "1"
 
   Electrode:
     attributes:
@@ -106,7 +106,7 @@ classes:
         implements:
           - linkml:elements
     annotations:
-      dimensions: 1
+      dimensions: "1"
 
   ElectricalDataMatrix:
     description: >-

--- a/tests/input/examples/schema_definition-array-2.yaml
+++ b/tests/input/examples/schema_definition-array-2.yaml
@@ -26,7 +26,7 @@ classes:
     implements:
       - linkml:NDArray
     annotations:
-      dimensions_info: "1"
+      dimensions: "1"
     # TODO abstract from children
 
   IrregularlySampledTimestampSeries:
@@ -47,7 +47,7 @@ classes:
         unit:
           ucum_code: s
     annotations:
-      dimensions_info: "1"
+      dimensions: "1"
 
   RegularlySampledTimestampSeries:
     is_a: TimestampSeries
@@ -82,7 +82,7 @@ classes:
         unit:
           ucum_code: s
     annotations:
-      dimensions_info: "1"
+      dimensions: "1"
 
   Electrode:
     attributes:
@@ -106,7 +106,7 @@ classes:
         implements:
           - linkml:elements
     annotations:
-      dimensions_info: "1"
+      dimensions: "1"
 
   ElectricalDataMatrix:
     description: >-
@@ -125,7 +125,7 @@ classes:
         unit:
           ucum_code: V
     annotations:
-      dimensions_info: 3
+      dimensions: 3
 
   ElectricalDataArray:
     implements:
@@ -154,7 +154,7 @@ classes:
         implements:
           - linkml:array
     annotations:
-      dimensions_info: 2
+      dimensions: 2
 
   IrregularlySampledElectricalDataArray:
     is_a: ElectricalDataArray
@@ -162,7 +162,7 @@ classes:
       time:
         range: IrregularlySampledTimestampSeries
     annotations:
-      dimensions_info: 2
+      dimensions: 2
 
   RegularlySampledElectricalDataArray:
     is_a: ElectricalDataArray
@@ -170,7 +170,7 @@ classes:
       time:
         range: RegularlySampledTimestampSeries
     annotations:
-      dimensions_info: 2
+      dimensions: 2
 
   File:
     tree_root: true

--- a/tests/input/examples/schema_definition-dynamic-enums.yaml
+++ b/tests/input/examples/schema_definition-dynamic-enums.yaml
@@ -163,7 +163,6 @@ enums:
       source_ontology: http://loinc.org
       source_nodes:
         - LP43571-6
-      relationship_types: null
       is_direct: true
       include_self: true
       traverse_up: false

--- a/tests/input/examples/schema_definition-instantiates.yaml
+++ b/tests/input/examples/schema_definition-instantiates.yaml
@@ -42,8 +42,10 @@ classes:
   Reviewable:
     class_uri: mymetamodel:Reviewable
     attributes:
-      description: an expert review of a schema element
-      review: Review
+      description:
+        description: an expert review of a schema element
+      review:
+        description: Review
 
   Review:
     class_uri: mymetamodel:Review

--- a/tests/input/examples/schema_definition-native-array-1.yaml
+++ b/tests/input/examples/schema_definition-native-array-1.yaml
@@ -38,7 +38,7 @@ classes:
         unit:
           ucum_code: deg
         array:
-          exact_dimensions: 1
+          exact_number_dimensions: 1
       longitude_in_deg:
         required: true
         range: float
@@ -46,7 +46,7 @@ classes:
         unit:
           ucum_code: deg
         array:
-          exact_dimensions: 1
+          exact_number_dimensions: 1
       time_in_d:
         range: float
         multivalued: true
@@ -56,7 +56,7 @@ classes:
         unit:
           ucum_code: d
         array:
-          exact_dimensions: 1
+          exact_number_dimensions: 1
       temperatures_in_K:
         range: float
         multivalued: true
@@ -64,5 +64,5 @@ classes:
         unit:
           ucum_code: K
         array:
-          exact_dimensions: 3
+          exact_number_dimensions: 3
 

--- a/tests/input/examples/schema_definition-native-array-1.yaml
+++ b/tests/input/examples/schema_definition-native-array-1.yaml
@@ -29,7 +29,7 @@ classes:
         multivalued: true
         unit:
           ucum_code: deg
-        array_shape:
+        array_info:
           exact_dimensions: 1
       longitude_in_deg:
         required: true
@@ -37,7 +37,7 @@ classes:
         multivalued: true
         unit:
           ucum_code: deg
-        array_shape:
+        array_info:
           exact_dimensions: 1
       time_in_d:
         range: float
@@ -47,7 +47,7 @@ classes:
         required: true
         unit:
           ucum_code: d
-        array_shape:
+        array_info:
           exact_dimensions: 1
       temperatures_in_K:
         range: float
@@ -55,7 +55,7 @@ classes:
         required: true
         unit:
           ucum_code: K
-        array_shape:
+        array_info:
           exact_dimensions: 3
           array_axes:
             x:

--- a/tests/input/examples/schema_definition-native-array-1.yaml
+++ b/tests/input/examples/schema_definition-native-array-1.yaml
@@ -1,0 +1,70 @@
+id: https://example.org/arrays
+name: arrays-temperature-example
+title: Array Temperature Example
+description: |-
+  Example LinkML schema to demonstrate a 3D DataArray of temperature values with labeled axes
+license: MIT
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  wgs84: http://www.w3.org/2003/01/geo/wgs84_pos#
+  example: https://example.org/
+
+default_prefix: example
+
+imports:
+  - linkml:types
+
+classes:
+
+  TemperatureDataset:
+    tree_root: true
+    attributes:
+      name:
+        identifier: true
+        range: string
+      latitude_in_deg:
+        required: true
+        range: float
+        multivalued: true
+        unit:
+          ucum_code: deg
+        array_shape:
+          exact_dimensions: 1
+      longitude_in_deg:
+        required: true
+        range: float
+        multivalued: true
+        unit:
+          ucum_code: deg
+        array_shape:
+          exact_dimensions: 1
+      time_in_d:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: d
+        array_shape:
+          exact_dimensions: 1
+      temperatures_in_K:
+        range: float
+        multivalued: true
+        required: true
+        unit:
+          ucum_code: K
+        array_shape:
+          exact_dimensions: 3
+          array_axes:
+            x:
+              rank: 0
+              alias: latitude_in_deg
+            y:
+              rank: 1
+              alias: longitude_in_deg
+            t:
+              rank: 2
+              alias: time_in_d
+

--- a/tests/input/examples/schema_definition-native-array-1.yaml
+++ b/tests/input/examples/schema_definition-native-array-1.yaml
@@ -57,7 +57,7 @@ classes:
           ucum_code: K
         array_info:
           exact_dimensions: 3
-          array_axes:
+          dimensions:
             x:
               rank: 0
               alias: latitude_in_deg

--- a/tests/input/examples/schema_definition-native-array-1.yaml
+++ b/tests/input/examples/schema_definition-native-array-1.yaml
@@ -19,6 +19,14 @@ classes:
 
   TemperatureDataset:
     tree_root: true
+    annotations:
+      array_data_mapping:
+        data: temperatures_in_K
+        dims: [x, y, t]
+        coords:
+          latitude_in_deg: x
+          longitude_in_deg: y
+          time_in_d: t
     attributes:
       name:
         identifier: true
@@ -57,14 +65,4 @@ classes:
           ucum_code: K
         array_info:
           exact_dimensions: 3
-          dimensions:
-            x:
-              rank: 0
-              alias: latitude_in_deg
-            y:
-              rank: 1
-              alias: longitude_in_deg
-            t:
-              rank: 2
-              alias: time_in_d
 

--- a/tests/input/examples/schema_definition-native-array-1.yaml
+++ b/tests/input/examples/schema_definition-native-array-1.yaml
@@ -37,7 +37,7 @@ classes:
         multivalued: true
         unit:
           ucum_code: deg
-        array_info:
+        array:
           exact_dimensions: 1
       longitude_in_deg:
         required: true
@@ -45,7 +45,7 @@ classes:
         multivalued: true
         unit:
           ucum_code: deg
-        array_info:
+        array:
           exact_dimensions: 1
       time_in_d:
         range: float
@@ -55,7 +55,7 @@ classes:
         required: true
         unit:
           ucum_code: d
-        array_info:
+        array:
           exact_dimensions: 1
       temperatures_in_K:
         range: float
@@ -63,6 +63,6 @@ classes:
         required: true
         unit:
           ucum_code: K
-        array_info:
+        array:
           exact_dimensions: 3
 

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -21,10 +21,10 @@ classes:
     attributes:
       rgb:
         range: float
-        array_info:
+        array:
           # NPtyping: NDArray[Shape["* x, * y, 3 rgb"]
           exact_dimensions: 3
-          dimensions_info:
+          dimensions:
             - alias: x
             - alias: y
             - alias: rgb
@@ -35,9 +35,9 @@ classes:
   SquareDataset:
     attributes:
       square_matrix:
-        array_info:
+        array:
           exact_dimensions: 2
-          dimensions_info:
+          dimensions:
             - alias: x
             - alias: y
             

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -23,7 +23,7 @@ classes:
         range: float
         array:
           # NPtyping: NDArray[Shape["* x, * y, 3 rgb"]
-          exact_dimensions: 3
+          exact_number_dimensions: 3
           dimensions:
             - alias: x
             - alias: y
@@ -36,7 +36,7 @@ classes:
     attributes:
       square_matrix:
         array:
-          exact_dimensions: 2
+          exact_number_dimensions: 2
           dimensions:
             - alias: x
             - alias: y

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -40,5 +40,13 @@ classes:
           dimensions:
             - alias: x
             - alias: y
-            
+
+  UnboundedTimeSeries:
+    attributes:
+      my_matrix:
+        range: float
+        array:
+          dimensions:
+            - alias: time
+          maximum_number_dimensions: False
 

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -25,9 +25,9 @@ classes:
           # NPtyping: NDArray[Shape["* x, * y, 3 rgb"]
           exact_dimensions: 3
           dimensions_info:
-            x:
-            y:
-            rgb:
+            - alias: x
+            - alias: y
+            - alias: rgb
               exact_cardinality: 3
               description: r, g, b values
               annotations:
@@ -38,7 +38,7 @@ classes:
         array_info:
           exact_dimensions: 2
           dimensions_info:
-            x:
-            y:
+            - alias: x
+            - alias: y
             
 

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -19,19 +19,14 @@ classes:
 
   RGBImage:
     attributes:
-      x:
-        range: integer
-      y:
-        range: integer
-
-    rgb:
-      range: float
-      array_shape:
-        exact_dimensions: 3
-        array_axes:
-          x:
-          y:
-          rgb:
-            exact_cardinality: 3
-            description: r, g, b values
+      rgb:
+        range: float
+        array_info:
+          exact_dimensions: 3
+          array_axes:
+            x:
+            y:
+            rgb:
+              exact_cardinality: 3
+              description: r, g, b values
 

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -22,6 +22,7 @@ classes:
       rgb:
         range: float
         array_info:
+          # NPtyping: NDArray[Shape["* x, * y, 3 rgb"]
           exact_dimensions: 3
           array_axes:
             x:
@@ -29,4 +30,15 @@ classes:
             rgb:
               exact_cardinality: 3
               description: r, g, b values
+              annotations:
+                names: [red, green, blue]
+  SquareDataset:
+    attributes:
+      square_matrix:
+        array_info:
+          exact_dimensions: 2
+          array_axes:
+            x:
+            y:
+            
 

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -24,7 +24,7 @@ classes:
         array_info:
           # NPtyping: NDArray[Shape["* x, * y, 3 rgb"]
           exact_dimensions: 3
-          dimensions:
+          dimensions_info:
             x:
             y:
             rgb:
@@ -37,7 +37,7 @@ classes:
       square_matrix:
         array_info:
           exact_dimensions: 2
-          dimensions:
+          dimensions_info:
             x:
             y:
             

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -24,20 +24,20 @@ classes:
         array_info:
           # NPtyping: NDArray[Shape["* x, * y, 3 rgb"]
           exact_dimensions: 3
-          array_axes:
+          dimensions:
             x:
             y:
             rgb:
               exact_cardinality: 3
               description: r, g, b values
               annotations:
-                names: [red, green, blue]
+                names: "[red, green, blue]"
   SquareDataset:
     attributes:
       square_matrix:
         array_info:
           exact_dimensions: 2
-          array_axes:
+          dimensions:
             x:
             y:
             

--- a/tests/input/examples/schema_definition-native-array-rgb.yaml
+++ b/tests/input/examples/schema_definition-native-array-rgb.yaml
@@ -1,0 +1,37 @@
+id: https://example.org/arrays
+name: arrays-temperature-example
+title: Array Temperature Example
+description: |-
+  Example LinkML schema to demonstrate a 3D DataArray of temperature values with labeled axes
+license: MIT
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  wgs84: http://www.w3.org/2003/01/geo/wgs84_pos#
+  example: https://example.org/
+
+default_prefix: example
+
+imports:
+  - linkml:types
+
+classes:
+
+  RGBImage:
+    attributes:
+      x:
+        range: integer
+      y:
+        range: integer
+
+    rgb:
+      range: float
+      array_shape:
+        exact_dimensions: 3
+        array_axes:
+          x:
+          y:
+          rgb:
+            exact_cardinality: 3
+            description: r, g, b values
+


### PR DESCRIPTION
See

- https://github.com/linkml/linkml/issues/895
- https://github.com/linkml/linkml-arrays/issues/5

This introduces first-class array support into LinkML. 

A minimal example would be:

```yaml
    attributes:
      temperature_matrix:
        range: float
        array_info:
          exact_dimensions: 3
```

The native serialization of this in json/yaml will be a LoLoL. Using linkml-xarrays it will be possible to serialize using hdf5/zarr/etc.

The corresponding nptyping type would be `NDArray[Shape["*, *, *"], Float]`.

(note: modelers will want the ability to use ctypes but this is orthogonal)

Note that this does not force any metadata on the array; we are deferring on the datamodel for what is equivalent to xarray DataArrays, these will be supported via `implements` for now and first-class incorporation in a future version. This will allow binding between axes are other LinkML arrays.

Minimal metadata can be introduced via naming the axes

```yaml
    attributes:
      temperature_matrix:
        range: float
        array_info:
          exact_dimensions: 3
          dimensions:
            x:
            y:
            z:
```

The corresponding nptyping type would be `NDArray[Shape["* x, * y, * z"], Float]`.

The shape can be further constrained; imagine an RGB matrix with coords x, y, and a length 3 r/g/b:

```yaml
    attributes:
      rgb:
        range: float
        array_info:
          exact_dimensions: 3
          dimensions:
            x:
            y:
            rgb:
              exact_cardinality: 3
              description: r, g, b values
              annotations:
                names: "[red, green, blue]"
```

corresponds to `NDArray[Shape["* x, * y, 3 rgb"]`

For now if you do want to bind dimensions to additional metadata this can be done via annotations:

```yaml
classes:

  TemperatureDataset:
    tree_root: true
    annotations:
      array_data_mapping:
        data: temperatures_in_K
        dims: [x, y, t]
        coords:
          latitude_in_deg: x
          longitude_in_deg: y
          time_in_d: t
    attributes:
      name:
        identifier: true
        range: string
      latitude_in_deg:
        required: true
        range: float
        multivalued: true
        unit:
          ucum_code: deg
        array_info:
          exact_dimensions: 1
      longitude_in_deg:
        required: true
        range: float
        multivalued: true
        unit:
          ucum_code: deg
        array_info:
          exact_dimensions: 1
      time_in_d:
        range: float
        multivalued: true
        implements:
          - linkml:elements
        required: true
        unit:
          ucum_code: d
        array_info:
          exact_dimensions: 1
      temperatures_in_K:
        range: float
        multivalued: true
        required: true
        unit:
          ucum_code: K
        array_info:
          exact_dimensions: 3
```