### PR TITLE
Remove Any range in maximum_number_dimensions

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1457,7 +1457,6 @@ slots:
       as a closed list and the maximum_number_dimensions is the length of the dimensions list, unless this
       value is set to False
     domain: array_expression
-    range: Anything
     any_of:
       - range: integer
         # minimum_value: 1


### PR DESCRIPTION
Noticed that `ArrayExpression.maximum_number_dimensions` had the wrong type: https://github.com/linkml/linkml-runtime/blob/c6943e41b67c9eb24f056c6ebaea2c78a0bdf4af/linkml_runtime/linkml_model/meta.py#L2730

```python
maximum_number_dimensions: Optional[Union[dict, Anything]] = None
```

should be

```python
maximum_number_dimensions: Optional[Union[int, bool]] = None
```

looks like a `range: Anything` was left in, I'm not sure if that resolves the range generation, but it also seems like something that should be validated in the metamodel schema: `range` shouldn't be specified by itself and in an `any_of` expression