### PR TITLE
Make `array` slot default false

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1431,6 +1431,7 @@ slots:
     inherited: true
     description: coerces the value of the slot into an array and defines the dimensions of that array
     status: testing
+    ifabsent: false
 
   dimensions:
     aliases:


### PR DESCRIPTION
Problem:

the way to specify an `Any` shaped array is to do this:

```yaml
classes:
  MyClass:
    attributes:
      my_array:
        array:
```

which rocks. The problem is that is equivalent to this from the POV of the python dataclasses:

```yaml
classes:
  MyClass:
    attributes:
      my_array:
```

so to make an any shaped array one has to, in practice, do something that is `False`-y but not `None` like:

```yaml
classes:
  MyClass:
    attributes:
      my_array:
        array: {}
```

Similarly to the semantic difference between `None` and `False` in `max_number_dimensions`, this PR makes the default value for the `array` slot `False`, making it distinguishable to `None` and preserving semantics. 

The alternative of keeping the default `None` and making any shaped arrays be `False` is desirable from a metamodel consistency POV, but counterintuitive - "what do you mean `array: False` means the most general array definition possible." Arguably, this is still consistent with metamodel intuition, because the default - as in "when one doesn't specify an array at all" - still means "No array," and specifying `array: None` is an affirmative signal that we want an `array` with `None` restrictions on its shape.

edit: actually now that i'm thinking about this, this also probably wouldn't work, so let's just say this issue is the "we need to figure out how to differentiate between `array: None` and `array` not being present on a class definition" PR

cc @cmungall @rly 