### PR TITLE
Add array class example

### DIFF
--- a/tests/input/examples/schema_definition-native-array-1.yaml
+++ b/tests/input/examples/schema_definition-native-array-1.yaml
@@ -22,10 +22,10 @@ classes:
     annotations:
       array_data_mapping:
         data: temperatures_in_K
-        dims: [x, y, t]
+        dims: [x, "y", t]
         coords:
           latitude_in_deg: x
-          longitude_in_deg: y
+          longitude_in_deg: "y"
           time_in_d: t
     attributes:
       name:

--- a/tests/input/examples/schema_definition-native-array-2.yaml
+++ b/tests/input/examples/schema_definition-native-array-2.yaml
@@ -1,0 +1,128 @@
+id: https://example.org/arrays
+name: arrays-temperature-example-2
+title: Array Temperature Example Using NDArray Classes
+description: |-
+  Example LinkML schema to demonstrate a 3D DataArray of temperature values with labeled axes
+  using LinkML NDArray classes
+license: MIT
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  wgs84: http://www.w3.org/2003/01/geo/wgs84_pos#
+  example: https://example.org/
+
+default_prefix: example
+
+imports:
+  - linkml:types
+
+classes:
+
+  TemperatureDataset:
+    tree_root: true
+    implements:
+      - linkml:DataArray
+    annotations:
+      array_data_mapping:
+        data: temperatures_in_K
+        dims: [x, "y", t]
+        coords:
+          latitude_in_deg: x
+          longitude_in_deg: "y"
+          time_in_d: t
+    attributes:
+      name:
+        identifier: true
+        range: string
+      latitude_in_deg:
+        implements:
+          - linkml:axis  # is this necessary/useful given the above array_data_mapping?
+        range: LatitudeSeries
+        # NOTE: LatitudeSeries could have multiple array attributes. use the one that implements linkml:elements
+        required: true
+        annotations:
+          axis_index: 0  # is this necessary/useful given the above array_data_mapping?
+      longitude_in_deg:
+        implements:
+          - linkml:axis
+        range: LongitudeSeries
+        required: true
+        annotations:
+          axis_index: 1
+      time_in_d:
+        implements:
+          - linkml:axis
+        range: DaySeries
+        required: true
+        annotations:
+          axis_index: 2
+      temperatures_in_K:
+        implements:
+          - linkml:DataArray_data  # changed from linkml:array
+        range: TemperatureMatrix
+        required: true
+
+  TemperatureMatrix:
+    description: A 3D array of temperatures
+    implements:
+      - linkml:NDArray
+      - linkml:RowOrderedArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: K
+        array:
+          exact_number_dimensions: 3
+
+  LatitudeSeries:
+    description: A series whose values represent latitude
+    implements:
+      - linkml:NDArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: deg
+        array:
+          exact_number_dimensions: 1
+
+  LongitudeSeries:
+    description: A series whose values represent longitude
+    implements:
+      - linkml:NDArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: deg
+        array:
+          exact_number_dimensions: 1
+
+  DaySeries:
+    description: A series whose values represent the days since the start of the measurement period
+    implements:
+      - linkml:NDArray
+    attributes:
+      values:
+        range: float
+        multivalued: true
+        implements:
+          - linkml:elements
+        required: true
+        unit:
+          ucum_code: d
+        array:
+          exact_number_dimensions: 1

--- a/tests/input/examples/schema_definition-native-array-2.yaml
+++ b/tests/input/examples/schema_definition-native-array-2.yaml
@@ -36,12 +36,11 @@ classes:
         range: string
       latitude_in_deg:
         implements:
-          - linkml:axis  # is this necessary/useful given the above array_data_mapping?
+          - linkml:axis
         range: LatitudeSeries
-        # NOTE: LatitudeSeries could have multiple array attributes. use the one that implements linkml:elements
         required: true
         annotations:
-          axis_index: 0  # is this necessary/useful given the above array_data_mapping?
+          axis_index: 0
       longitude_in_deg:
         implements:
           - linkml:axis
@@ -58,7 +57,7 @@ classes:
           axis_index: 2
       temperatures_in_K:
         implements:
-          - linkml:DataArray_data  # changed from linkml:array
+          - linkml:array
         range: TemperatureMatrix
         required: true
 


### PR DESCRIPTION
This PR adds an alternate approach to specifying the `TemperatureDataset` defined in `tests/input/examples/schema_definition-native-array-1.yaml`. This approach uses classes that implement [`linkml:NDArray`](https://github.com/linkml/linkml-model/blob/main/linkml_model/model/schema/array.yaml) and have an attribute that implements `linkml:elements` as defined pre-1.7.0 release. This representation is necessary for adding additional attributes, e.g., user-specified units of measurement, conversion factor, precision/error, reference/zero point, or source, on the various arrays that make up a `TemperatureDataset`. Seeking feedback on this approach.

It also changes `y` -> `"y"` because `y` = True in YAML 1.1.