### PR TITLE
remove domain from is_a, mixin, mixins per ticket 1261

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -530,6 +530,7 @@ slots:
   mixin:
     aliases:
       - trait
+    domain: definition
     range: boolean
     description: >-
       Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins.

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -502,7 +502,6 @@ slots:
   # --------------------------------------------------------------
   is_a:
     rank: 11
-    domain: definition
     range: definition
     abstract: true
     description: >-
@@ -531,7 +530,6 @@ slots:
   mixin:
     aliases:
       - trait
-    domain: definition
     range: boolean
     description: >-
       Indicates the class or slot is intended to be inherited from without being an is_a parent. mixins should not be inherited from using is_a, except by other mixins.
@@ -546,7 +544,6 @@ slots:
     rank: 13
     aliases:
       - traits
-    domain: definition
     multivalued: true
     range: definition
     description: >-


### PR DESCRIPTION
fixes #1261 as directed in the ticket. https://github.com/linkml/linkml/issues/1261
identified in ticket triage.
so that permissible values can use `is_a`and `mixins` 