### PR TITLE
Adding enum bindings

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -618,7 +618,6 @@ slots:
       - BasicSubset
 
   pv_formula:
-    domain: enum_expression
     range: pv_formula_options
     description: >-
       Defines the specific formula to be used to generate the permissible values.
@@ -1543,7 +1542,7 @@ slots:
     domain: slot_definition
     range: presence_enum
     inherited: true
-    description: if true then a value must be present (for lists there must be at least one value). If false then a value must be absent (for lists, must be empty)
+    description: if PRESENT then a value must be present (for lists there must be at least one value). If ABSENT then a value must be absent (for lists, must be empty)
     comments:
       - if set to true this has the same effect as required=true. In contrast, required=false allows a value to be present
     status: unstable
@@ -2098,6 +2097,32 @@ slots:
     in_subset:
       - SpecificationSubset
 
+  bindings:
+    domain: element
+    range: enum_binding
+    multivalued: true
+    inlined: true
+    description: >-
+      A collection of slot bindings that specify how a slot can be bound to a permissible value
+      from an enumeration.
+    in_subset:
+      - SpecificationSubset
+
+  binds_value_of:
+    domain: enum_binding
+    range: string
+    description: >-
+      A path to a slot that is being bound to a permissible value from an enumeration.
+    in_subset:
+      - SpecificationSubset
+
+  obligation_level:
+    range: obligation_level_enum
+    description: >-
+      The level of obligation or recommendation strength for a metadata element
+    in_subset:
+      - SpecificationSubset
+
 
   # -----------------------------------
   # Slots for type definition
@@ -2520,6 +2545,7 @@ classes:
       - generation_date
       - slot_names_unique
       - settings
+      - bindings
     see_also:
       - https://en.wikipedia.org/wiki/Data_dictionary
     close_mappings:
@@ -2673,6 +2699,24 @@ classes:
     slots:
       - enum_uri
 
+  enum_binding:
+    description: >-
+      A binding of a slot or a class to a permissible value from an enumeration
+    slots:
+      - range
+      - obligation_level
+      - binds_value_of
+      - pv_formula
+    slot_usage:
+      range:
+        range: enum_definition
+    in_subset:
+      - SpecificationSubset
+    mixins:
+      - extensible
+      - annotatable
+      - common_metadata
+
   match_query:
     description: >-
       A query that is used on an enum expression to dynamically obtain a set of permissivle values via a query that 
@@ -2772,6 +2816,7 @@ classes:
       - range
       - range_expression
       - enum_range
+      - bindings
       - required
       - recommended
       - inlined
@@ -3192,3 +3237,28 @@ enums:
         meaning: skos:broaderMatch
       NARROW_SYNONYM:
         meaning: skos:narrowerMatch
+
+  obligation_level_enum:
+    rank: 10
+    description: >-
+      The level of obligation or recommendation strength for a metadata element
+    permissible_values:
+      REQUIRED:
+        description: >-
+          The metadata element is required to be present in the model
+      RECOMMENDED:
+        aliases:
+          - ENCOURAGED
+        description: >-
+          The metadata element is recommended to be present in the model
+      OPTIONAL:
+        description: >-
+          The metadata element is optional to be present in the model
+      EXAMPLE:
+        description: >-
+          The metadata element is an example of how to use the model
+      DISCOURAGED:
+        description: >-
+          The metadata element is allowed but discouraged to be present in the model
+    in_subset:
+      - SpecificationSubset

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -2106,6 +2106,15 @@ slots:
     description: >-
       A collection of enum bindings that specify how a slot can be bound to a permissible value
       from an enumeration.
+
+      LinkML provides enums to allow string values to be restricted to one of a set of permissible
+      values (specified statically or dynamically).
+
+      Enum bindings allow enums to be bound to any object, including complex nested objects. For
+      example, given a (generic) class Concept with slots id and label, it may be desirable to restrict the
+      values the id takes on in a given context. For example, a HumanSample class may have a slot for
+      representing sample site, with a range of concept, but the values of that slot may be restricted to
+      concepts from a particular branch of an anatomy ontology.
     in_subset:
       - SpecificationSubset
 

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -2102,8 +2102,9 @@ slots:
     range: enum_binding
     multivalued: true
     inlined: true
+    status: testing
     description: >-
-      A collection of slot bindings that specify how a slot can be bound to a permissible value
+      A collection of enum bindings that specify how a slot can be bound to a permissible value
       from an enumeration.
     in_subset:
       - SpecificationSubset
@@ -2701,7 +2702,7 @@ classes:
 
   enum_binding:
     description: >-
-      A binding of a slot or a class to a permissible value from an enumeration
+      A binding of a slot or a class to a permissible value from an enumeration.
     slots:
       - range
       - obligation_level

--- a/tests/input/examples/schema_definition-enum_bindings-1.yaml
+++ b/tests/input/examples/schema_definition-enum_bindings-1.yaml
@@ -28,7 +28,7 @@ classes:
     attributes:
       id:
         identifier: true
-        descrption: CURIE/identifier for the concept. E.g. ENVO:1234567
+        description: CURIE/identifier for the concept. E.g. ENVO:1234567
       name:
         description: human-readable label of the concept. E.g. "blood"
       vocabulary:

--- a/tests/input/examples/schema_definition-enum_bindings-1.yaml
+++ b/tests/input/examples/schema_definition-enum_bindings-1.yaml
@@ -1,0 +1,47 @@
+id: https://example.org/enum_bindings
+name: enum_bindings_example
+title: Enum Bindings Example
+description: |-
+  Example LinkML schema to demonstrate Enum bindings
+license: MIT
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  example: https://example.org/
+
+default_prefix: example
+
+imports:
+  - linkml:types
+
+classes:
+
+  Concept:
+    attributes:
+      id:
+        identifier: true
+      name:
+
+  Biosample:
+    attributes:
+      name:
+      sample_material_type:
+        range: Concept
+        bindings:
+          - binds_value_of: id
+            range: ENVOMaterialEnum
+            strength: RECOMMENDED
+            description: Material type from the ENVO ontology
+
+enums:
+  ENVOMaterialEnum:
+    description: Material type from the ENVO ontology
+    reachable_from:
+      source_ontology: obo:envo
+      source_nodes:
+        - ENVO:00010483  ## environmental material
+      is_direct: false
+      relationship_types:
+        - rdfs:subClassOf
+
+

--- a/tests/input/examples/schema_definition-enum_bindings-1.yaml
+++ b/tests/input/examples/schema_definition-enum_bindings-1.yaml
@@ -2,7 +2,14 @@ id: https://example.org/enum_bindings
 name: enum_bindings_example
 title: Enum Bindings Example
 description: |-
-  Example LinkML schema to demonstrate Enum bindings
+  Example LinkML schema to demonstrate Enum bindings.
+
+  Here we define a generic Sample class which has a range indicating
+  the material type of the sample. In an environmental context this
+  could be soil, seawater, etc. In a medical context it may be human
+  tissue.
+
+  In both cases we want to use a generic Concept class
 license: MIT
 
 prefixes:
@@ -17,26 +24,58 @@ imports:
 classes:
 
   Concept:
+    description: A generic class for representing an element from a vocabulary or ontology.
     attributes:
       id:
         identifier: true
+        descrption: CURIE/identifier for the concept. E.g. ENVO:1234567
       name:
+        description: human-readable label of the concept. E.g. "blood"
+      vocabulary:
+        description: E.g. UBERON, PO, ENVO, NCIT
 
 
   Sample:
+    description: Abstract grouping for different sample types
+    abstract: true
     attributes:
       name:
+        description: E.g. my blood sample
       sample_material_type:
+        description: The material type for the sample - depending on the type of sample, could be tissue (e.g. blood, muscle) or environmental (rock, soil, ...)
         range: Concept
             
   EnvironmentalMaterialSample:
+    description: A sample taken from the environment
     slot_usage:
       sample_material_type:
+        description: Environmental material type
         bindings:
           - binds_value_of: id
             range: ENVOMaterialEnum
             obligation_level: RECOMMENDED
             description: Material type from the ENVO ontology
+
+  HumanSampleSample:
+    description: A sample taken from a human subject
+    slot_usage:
+      sample_material_type:
+        description: Tissue material type
+        bindings:
+          - binds_value_of: id
+            range: AnatomyMaterialEnum
+            obligation_level: RECOMMENDED
+            description: Material type from an anatomy ontology
+
+  AlternateHumanSampleSample:
+    description: A sample taken from a human subject (alternative example for illustrative purposes)
+    slot_usage:
+      sample_material_type:
+        description: Does not constrain the ID that is used, but restricts the vocabulary field to a fixed enum
+        bindings:
+          - binds_value_of: vocabulary
+            range: HumanSampleVocabularyEnum
+            obligation_level: RECOMMENDED
 
 enums:
   ENVOMaterialEnum:
@@ -48,5 +87,19 @@ enums:
       is_direct: false
       relationship_types:
         - rdfs:subClassOf
+  AnatomyMaterialEnum:
+    description: Material type from the UBERON anatomy ontology
+    reachable_from:
+      source_ontology: obo:uberon
+      source_nodes:
+        - UBERON:0000465 ## material anatomical entity
+      is_direct: false
+      relationship_types:
+        - rdfs:subClassOf
+  HumanSampleVocabularyEnum:
+    permissible_values:
+      UBERON:
+      FMA:
+      NCIT:
 
 

--- a/tests/input/examples/schema_definition-enum_bindings-1.yaml
+++ b/tests/input/examples/schema_definition-enum_bindings-1.yaml
@@ -22,15 +22,20 @@ classes:
         identifier: true
       name:
 
-  Biosample:
+
+  Sample:
     attributes:
       name:
       sample_material_type:
         range: Concept
+            
+  EnvironmentalMaterialSample:
+    slot_usage:
+      sample_material_type:
         bindings:
           - binds_value_of: id
             range: ENVOMaterialEnum
-            strength: RECOMMENDED
+            obligation_level: RECOMMENDED
             description: Material type from the ENVO ontology
 
 enums:


### PR DESCRIPTION
In LinkML enums are a special kind of element, distinct from TypeDefinition, ClassDefinition (even they are rendered as strings).

Sometimes it can be useful to bind an existing slot value to an enum. 

One use case is when we have a generic `Concept` class that is typically non-lined, and referred to by id. We may want to have a slot usage that restricts the id to ne PVs in some contexts; e.g.

```yaml
classes:

  Concept:
    attributes:
      id:
        identifier: true
      name:

  Biosample:
    attributes:
      name:
      sample_material_type:
        range: Concept
        bindings:
          - binds_value_of: id
            range: ENVOMaterialEnum
            strength: RECOMMENDED
            description: Material type from the ENVO ontology

enums:
  ENVOMaterialEnum:
    description: Material type from the ENVO ontology
    reachable_from:
      source_ontology: obo:envo
      source_nodes:
        - ENVO:00010483  ## environmental material
      is_direct: false
      relationship_types:
        - rdfs:subClassOf
```

See also https://build.fhir.org/terminologies-binding-examples.html