### PR TITLE
Adding is_a and mixins to slots for permissible_value.

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -3104,6 +3104,8 @@ classes:
       - unit
       - instantiates
       - implements
+      - is_a
+      - mixins
     in_subset:
       - SpecificationSubset
       - BasicSubset


### PR DESCRIPTION
Fixes https://github.com/linkml/linkml/issues/1680
