### PR TITLE
move array to slot_expression

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -2880,6 +2880,7 @@ classes:
       - exactly_one_of
       - any_of
       - all_of
+      - array
     slot_usage:
       any_of:
         range: anonymous_slot_expression
@@ -2915,7 +2916,6 @@ classes:
       - singular_name
       - domain
       - slot_uri
-      - array
       - inherited
       - readonly
       - ifabsent


### PR DESCRIPTION
fix: https://github.com/linkml/linkml-model/issues/199

I think just moving `array` to `slot_expression` would solve the problem, because `slot_definition` received the `slot_expression` mixin, which uses `slot_usage` to change the `range` of `any_of` to `anonymous_slot_expression`, which also receives the `slot_expression` mixin.