### PR TITLE
fix: decouple 'curie' uri from 'uri' uri

### DIFF
--- a/linkml_model/model/schema/types.yaml
+++ b/linkml_model/model/schema/types.yaml
@@ -123,7 +123,7 @@ types:
       If you are authoring schemas in LinkML YAML, the type is referenced with the lower case "date_or_datetime".
 
   uriorcurie:
-    uri: xsd:anyURI
+    uri: linkml:UriOrCurie
     base: URIorCURIE
     repr: str
     description: a URI or a CURIE
@@ -131,7 +131,7 @@ types:
       If you are authoring schemas in LinkML YAML, the type is referenced with the lower case "uriorcurie".
 
   curie:
-    uri: xsd:string
+    uri: linkml:Curie
     base: Curie
     repr: str
     description: a compact URI


### PR DESCRIPTION
The URIs assigned to the different types identify the types themselves, as a consequence two different types with the same URI would be expected to be synonyms (different names with the same meaning).

This is the case for the types CURIE and URIorCURIE:
1. CURIE had the URI 'xsd:anyURI' (the same as for URIs).
2. URIorCURIE had the URI 'xsd:string' (the same as for strings).

This patch assign both CURIE and URIorCURIE their own unique URIs to differentiate the different types from each other.