### PR TITLE
add extra_slots metamodel slot

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1359,9 +1359,9 @@ slots:
       
       Possible values:
       - `allowed: true` - allow all additional data
-      - `allowed: false` (or `allowed:` or `allowed: null` while `slot_expression` is `null`) - 
+      - `allowed: false` (or `allowed:` or `allowed: null` while `anonymous_slot_expression` is `null`) - 
         forbid all additional data (default) 
-      - `slot_expression: ...`  - allow additional data if it matches the slot expression (see examples)
+      - `anonymous_slot_expression: ...`  - allow additional data if it matches the slot expression (see examples)
     domain: class_definition
     ifabsent: false
     range: extra_slots_expression
@@ -1376,21 +1376,21 @@ slots:
           allowed: false
         description: Forbid any additional data
       - value:
-          slot_expression:
+          anonymous_slot_expression:
             range: string
         description: Allow additional data that are strings
       - value:
-          slot_expression:
+          anonymous_slot_expression:
             range: AClassDefinition
         description: Allow additional data if they are instances of the class definition "AClassDefinition"
       - value:
-          slot_expression:
+          anonymous_slot_expression:
             any_of:
               - range: string
               - range: integer
         description: allow additional data if they are either strings or integers
       - value:
-          slot_expression:
+          anonymous_slot_expression:
             range: integer
             multivalued: true
             maximum_cardinality: 5
@@ -1398,7 +1398,7 @@ slots:
           Allow additional data if they are lists of integers of at most length 5.
           Note that this does *not* mean that a maximum of 5 extra slots are allowed.
       - value:
-          slot_expression:
+          anonymous_slot_expression:
             range: integer
             required: true
         description: |
@@ -1406,11 +1406,11 @@ slots:
           `required` is meaningless in this context and ignored, since by definition all "extra" slots are optional.
       - value:
           allowed: false
-          slot_expression:
+          anonymous_slot_expression:
             range: string
         description: |
           A semantically *invalid* use of `extra_slots`, as extra slots will be forbidden and the 
-          `slot_expression` will be ignored.
+          `anonymous_slot_expression` will be ignored.
 
   allowed:
     description: Whether or not something is allowed. Usage defined by context.
@@ -3302,7 +3302,7 @@ classes:
       - expression
     slots:
       - allowed
-      - slot_expression
+      - anonymous_slot_expression
 
 
 # ==================================

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1358,46 +1358,66 @@ slots:
       Note that this does *not* define the constraints that are placed on additional slots defined by inheriting classes.
       
       Possible values:
-      - true: allow any additional data
-      - false: (default) forbid any additional data
-      - anonymous_slot_expression: allow only data matching this anonymous slot expression
+      - `allowed: true` - allow all additional data
+      - `allowed: false` (or `allowed:` or `allowed: null` while `slot_expression` is `null`) - 
+        forbid all additional data (default) 
+      - `slot_expression: ...`  - allow additional data if it matches the slot expression (see examples)
     domain: class_definition
     ifabsent: false
-    any_of:
-      - range: boolean
-      - range: anonymous_slot_expression
+    range: extra_slots_expression
     in_subset:
       - SpecificationSubset
       - BasicSubset
     examples:
-      - value: true
+      - value:
+          allowed: true
         description: Allow all additional data
-      - value: false
+      - value:
+          allowed: false
         description: Forbid any additional data
       - value:
-          range: string
+          slot_expression:
+            range: string
         description: Allow additional data that are strings
       - value:
-          range: AClassDefinition
+          slot_expression:
+            range: AClassDefinition
         description: Allow additional data if they are instances of the class definition "AClassDefinition"
       - value:
-          any_of:
-            - range: string
-            - range: integer
+          slot_expression:
+            any_of:
+              - range: string
+              - range: integer
         description: allow additional data if they are either strings or integers
       - value:
-          range: integer
-          multivalued: true
-          maximum_cardinality: 5
+          slot_expression:
+            range: integer
+            multivalued: true
+            maximum_cardinality: 5
         description: |
           Allow additional data if they are lists of integers of at most length 5.
           Note that this does *not* mean that a maximum of 5 extra slots are allowed.
       - value:
-          range: integer
-          required: true
+          slot_expression:
+            range: integer
+            required: true
         description: |
           Allow additional data if they are integers. 
           `required` is meaningless in this context and ignored, since by definition all "extra" slots are optional.
+      - value:
+          allowed: false
+          slot_expression:
+            range: string
+        description: |
+          A semantically *invalid* use of `extra_slots`, as extra slots will be forbidden and the 
+          `slot_expression` will be ignored.
+
+  allowed:
+    description: Whether or not something is allowed. Usage defined by context.
+    range: boolean
+    in_subset:
+      - SpecificationSubset
+      - BasicSubset
 
   # -----------------------------------
   # Slot definition slots
@@ -3272,6 +3292,18 @@ classes:
       - string_serialization
     in_subset:
       - SpecificationSubset
+
+  extra_slots_expression:
+    description: |
+      An expression that defines how to handle additional data in an instance of class
+      beyond the slots/attributes defined for that class. 
+      See `extra_slots` for usage examples.
+    mixins:
+      - expression
+    slots:
+      - allowed
+      - slot_expression
+
 
 # ==================================
 # Enumerations                     #

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1398,8 +1398,6 @@ slots:
         description: |
           Allow additional data if they are integers. 
           `required` is meaningless in this context and ignored, since by definition all "extra" slots are optional.
-        
-    
 
   # -----------------------------------
   # Slot definition slots

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1419,9 +1419,6 @@ slots:
       - SpecificationSubset
       - BasicSubset
 
-  slot:
-    description: A
-
   # -----------------------------------
   # Slot definition slots
   # -----------------------------------

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1355,7 +1355,9 @@ slots:
   extra_slots:
     description: |
       How a class instance handles extra data not specified in the class definition.
+      Note that this does *not* define the constraints that are placed on additional slots defined by inheriting classes.
       
+      Possible values:
       - true: allow any additional data
       - false: (default) forbid any additional data
       - anonymous_slot_expression: allow only data matching this anonymous slot expression
@@ -1367,6 +1369,36 @@ slots:
     in_subset:
       - SpecificationSubset
       - BasicSubset
+    examples:
+      - value: true
+        description: Allow all additional data
+      - value: false
+        description: Forbid any additional data
+      - value:
+          range: string
+        description: Allow additional data that are strings
+      - value:
+          range: AClassDefinition
+        description: Allow additional data if they are instances of the class definition "AClassDefinition"
+      - value:
+          any_of:
+            - range: string
+            - range: integer
+        description: allow additional data if they are either strings or integers
+      - value:
+          range: integer
+          multivalued: true
+          maximum_cardinality: 5
+        description: |
+          Allow additional data if they are lists of integers of at most length 5.
+          Note that this does *not* mean that a maximum of 5 extra slots are allowed.
+      - value:
+          range: integer
+          required: true
+        description: |
+          Allow additional data if they are integers. 
+          `required` is meaningless in this context and ignored, since by definition all "extra" slots are optional.
+        
     
 
   # -----------------------------------

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1351,6 +1351,22 @@ slots:
     range: boolean
     description: if true then induced/mangled slot names are not created for class_usage and attributes
     status: testing
+
+  extra_slots:
+    description: |
+      How a class instance handles extra data not specified in the class definition.
+      
+      - true: allow any additional data
+      - false: (default) forbid any additional data
+      - anonymous_slot_expression: allow only data matching this anonymous slot expression
+    domain: class_definition
+    ifabsent: false
+    any_of:
+      - range: boolean
+      - range: anonymous_slot_expression
+    in_subset:
+      - SpecificationSubset
+      - BasicSubset
     
 
   # -----------------------------------
@@ -3023,6 +3039,7 @@ classes:
       - represents_relationship
       - disjoint_with
       - children_are_mutually_disjoint
+      - extra_slots
     slot_usage:
       is_a:
         range: class_definition

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1359,9 +1359,9 @@ slots:
       
       Possible values:
       - `allowed: true` - allow all additional data
-      - `allowed: false` (or `allowed:` or `allowed: null` while `anonymous_slot_expression` is `null`) - 
+      - `allowed: false` (or `allowed:` or `allowed: null` while `range_expression` is `null`) - 
         forbid all additional data (default) 
-      - `anonymous_slot_expression: ...`  - allow additional data if it matches the slot expression (see examples)
+      - `range_expression: ...`  - allow additional data if it matches the slot expression (see examples)
     domain: class_definition
     ifabsent: false
     range: extra_slots_expression
@@ -1376,21 +1376,21 @@ slots:
           allowed: false
         description: Forbid any additional data
       - value:
-          anonymous_slot_expression:
+          range_expression:
             range: string
         description: Allow additional data that are strings
       - value:
-          anonymous_slot_expression:
+          range_expression:
             range: AClassDefinition
         description: Allow additional data if they are instances of the class definition "AClassDefinition"
       - value:
-          anonymous_slot_expression:
+          range_expression:
             any_of:
               - range: string
               - range: integer
         description: allow additional data if they are either strings or integers
       - value:
-          anonymous_slot_expression:
+          range_expression:
             range: integer
             multivalued: true
             maximum_cardinality: 5
@@ -1398,7 +1398,7 @@ slots:
           Allow additional data if they are lists of integers of at most length 5.
           Note that this does *not* mean that a maximum of 5 extra slots are allowed.
       - value:
-          anonymous_slot_expression:
+          range_expression:
             range: integer
             required: true
         description: |
@@ -1406,7 +1406,7 @@ slots:
           `required` is meaningless in this context and ignored, since by definition all "extra" slots are optional.
       - value:
           allowed: false
-          anonymous_slot_expression:
+          range_expression:
             range: string
         description: |
           A semantically *invalid* use of `extra_slots`, as extra slots will be forbidden and the 
@@ -1418,6 +1418,9 @@ slots:
     in_subset:
       - SpecificationSubset
       - BasicSubset
+
+  slot:
+    description: A
 
   # -----------------------------------
   # Slot definition slots
@@ -3302,7 +3305,7 @@ classes:
       - expression
     slots:
       - allowed
-      - anonymous_slot_expression
+      - range_expression
 
 
 # ==================================


### PR DESCRIPTION
Related to:
- proposal: https://github.com/linkml/linkml/issues/2241
- https://github.com/linkml/linkml/issues/2238
- https://github.com/linkml/linkml/issues/1404

Many modeling frameworks allow one to specify how to handle extra values provided to an instance of a class. By default linkml forbids all additional data in those frameworks that allow that. In addition to declaring whether or not extra data is allowed, it would also be nice to constrain what type that extra data can be. There are no other existing linkml metamodel items that could be used for this that i am aware of, but please let me know if we can repurpose something existing here.

# Options

## Option 1: Single slot

(current contents of PR, simplified) 

```yaml
  extra_slots:
    ifabsent: false
    any_of:
      - range: boolean
      - range: anonymous_slot_expression
```

## Option 2: Class slot

If we want to avoid doing `any_of` in the metamodel, we could also do something like this:

```yaml
slots:
  extra_slots:
    range: ExtraSlotsExpression
  allowed:
    range: boolean

classes:
  ExtraSlotsExpression:
    mixins:
      - expression
    slots:
      - allowed
      - slot_expression

```

I'm not sure if there is a general "allowed" slot, ctrl+f isn't finding one, but seems better than making a single-purpose "extra_slots_allowed" slot. Maybe `slot_expression` should be `anonymous_slot_expression` here but that seems like a lot to type when defining a schema lol, idk if that is incorrect semantically.

this makes one awkward case which is syntactically possible but semantically impossible

| allowed | slot_expression | valid |
| --- | --- | --- |
| True | null | True |
| False | null | True |
| True | present | True |
| False | present | False |

And also doesn't allow us to `ifabsent` `allowed` to `False` because a `slot_expression` should be able to be specified without explicitly setting `allowed: true` imo. So the "default `allowed: False`" behavior becomes "extra slots are not allowed if `allowed: false` or `allowed: null && slot_expression: null`"

# Examples

the examples in the PR and the prior issue give examples of expected use, but for the sake of recordkeeping:

## Allow all extra slots:

<table>
<tr>
<th>Single Slot</th>
<th>Class Slot</th>
</tr>
<tr>
<td>

```yaml
MyClass:
  extra_slots: true
```

</td>
<td>

```yaml
MyClass:
  extra_slots:
    allowed: true
```

</td>
</tr>
</table>

### JSON Schema

assuming `"$schema": "https://json-schema.org/draft/2020-12/schema"` for all these, and adding a dummy "foo" slot because it's just empty otherwise

```json
{
  "properties": {
    "foo": { "type": "string" }
  },
  "additionalProperties": true
}
```

### Pydantic

```python
class MyModel(BaseModel):
    model_config = ConfigDict(extra='allow')
```


## Allow no extra slots (default)

<table>
<tr>
<th>Single Slot</th>
<th>Class Slot</th>
</tr>
<tr>
<td>

```yaml
MyClass:
  extra_slots: false
```

or undefined

```yaml
MyClass:
  # nothing
```

</td>
<td>

```yaml
MyClass:
  extra_slots:
    allowed: false
```

or undefined

```yaml
MyClass:
  # nothing
```

</td>
</tr>
</table>

### JSON Schema

```json
{
  "properties": {
    "foo": { "type": "string" }
  },
  "additionalProperties": false
}
```

### Pydantic

(in reality we wouldn't set this, because it's both pydantic's default and also the default in the `ConfiguredBaseClass`, but for illustration...)

```python
class MyModel(BaseModel):
    model_config = ConfigDict(extra='forbid')
```


## Constrain extra slots by slot expression

### Simple Types

Only allow additional strings

<table>
<tr>
<th>Single Slot</th>
<th>Class Slot</th>
</tr>
<tr>
<td>

```yaml
MyClassA:
  extra_slots:
    range: string
```

</td>
<td>

```yaml
MyClassA:
  extra_slots:
    # not required, but equivalent
    # allowed: true
    slot_expression: 
      range: string
```

</td>
</tr>
</table>

#### JSON Schema

`additionalProperties` also accepts a schema object...

```json
{
  "properties": {
    "foo": { "type": "string" }
  },
  "additionalProperties": { "type": "string" }
}
```

#### Pydantic

```python
class MyModel(BaseModel):
    __pydantic_extra__: dict[str, str] = Field(init=False)
    model_config = ConfigDict(extra='allow')
```


### Unions

<table>
<tr>
<th>Single Slot</th>
<th>Class Slot</th>
</tr>
<tr>
<td>

```yaml
MyClass:
  extra_slots:
    any_of:
      - range: string
      - range: integer
```

</td>
<td>

```yaml
MyClass:
  extra_slots:
    slot_expression:
      any_of:
        - range: string
        - range: integer
```

</td>
</tr>
</table>


#### JSON Schema

```json
{
  "properties": {
    "foo": { "type": "string" }
  },
  "additionalProperties": { "anyOf": [ {"type": "string"}, {"type": "integer"} ] }
}
```

#### Pydantic

```python
class MyModel(BaseModel):
    __pydantic_extra__: dict[str, str | int ] = Field(init=False)
    model_config = ConfigDict(extra='allow')
```

### Class Ranges

Allow extra slots if they are instances of the class `SecondClass`

<table>
<tr>
<th>Single Slot</th>
<th>Class Slot</th>
</tr>
<tr>
<td>

```yaml
MyClass:
  extra_slots:
    range: SecondClass
```

</td>
<td>

```yaml
MyClass:
  extra_slots:
    slot_expression:
      range: SecondClass
```

</td>
</tr>
</table>


#### JSON Schema

```json
{
  "$defs": {
    "SecondClass": {
      "additionalProperties": false,
      "properties":
      {
        "bar": { "type": "integer" }
      }
    }
  },
  "properties": {
    "foo": { "type": "string" }
  },
  "additionalProperties": {
    "$ref": "#/$defs/SecondClass"
  }
}
```

#### Pydantic

```python
class SecondClass(BaseModel):
    bar: int

class MyModel(BaseModel):
    __pydantic_extra__: dict[str, SecondClass] = Field(init=False)
    model_config = ConfigDict(extra='allow')
```

# Discussion

## Ambiguity

The two major points of ambiguity that i can see
- interpreting this as defining constraints on extra slots defined in child classes (seems relatively low likelihood, but possible). Added a note in the description for this property to head that off
- interpreting some properties of an anonymous slot expression as being about the requiredness or cardinality of extra slots (seems more likely). eg. one might think they could set `maximum_cardinality` to limit the number of extra slots that could be provided, or make providing extra slots `required`. Added examples to clarify these behaviors - I am not sure if there is a circumstance where we would want to support that, but if we did then we could turn this into a class so someone could specify something like this, which would be backwards compatible with any `anonymous_slot_expression` definitions that happen in the meantime:
```yaml
extra_slots:
  extra_params:
    maximum_cardinality: 5
  # the rest of the anonymous slot expression..
  range: string
  multivalued: true
  maximum_cardinality: 3
```

to mean "there can be at most 5 extra slots that are lists of strings at most length 3"

## Naming

"Extra slots" might be a bit too specific, are there other cases where we would want to allow/deny extra things in a domain? @sierra-moxon brings up the name "`closed`" which has currency in closed-world/open-world parlance of RDF and formal logic circles, but is less obvious to your average data modeler. 

---


This is high priority for me since it's blocking final implementation of nwb-linkml, so if we can make relatively short work of this then i'll implement it for pydanticgen, pythongen, and json schema gen as thanks for the quickness.