### PR TITLE
Add URI or CURIE range documentation

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1448,6 +1448,7 @@ slots:
     inherited: true
     comments:
       - range is underspecified, as not all elements can appear as the range of a slot.
+      - to use a URI or CURIE as the range, create a class with the URI or curie as the class_uri
     description: |
       defines the type of the object of the slot.  Given the following slot definition
         S1:
@@ -1476,6 +1477,7 @@ slots:
       URI of the class that provides a semantic interpretation of the slot in a linked data context. The URI may come from any namespace and may be shared between schemas.
     comments:
       - Assigning slot_uris can provide additional hooks for interoperation, indicating a common conceptual model
+      - To use a URI or CURIE as a range, create a class with the URI or CURIE as the class_uri
     in_subset:
       - SpecificationSubset
       - BasicSubset


### PR DESCRIPTION
This is just a tiny patch that adds a couple of comments to document that a URI or CURIE has to be created as a class in order to be used as a range for a slot.