### PR TITLE
add simple_dict annotations to extensions

### DIFF
--- a/linkml_model/model/schema/extensions.yaml
+++ b/linkml_model/model/schema/extensions.yaml
@@ -38,6 +38,8 @@ slots:
     alias: value
     required: true
     range: AnyValue
+    annotations:
+      simple_dict_value: true
 
 
 classes:


### PR DESCRIPTION
## Summary

Adds explicit `simple_dict_value: true` annotation to the `extension_value` slot in `extensions.yaml`, aligning the source schema with what's already present in derived artifacts (`meta.jsonld`, `meta.owl.ttl`).

## Motivation

The `extension` class has three slots: `extension_tag` (key), `extension_value` (required), and `extensions` (recursive self-reference, not required). Generators need to know which non-key slot holds the dict value to serialize extensions as simple `{tag: value}` dicts.

Currently this works via heuristic inference in `get_range_associated_slots()` — `extension_value` is the only non-key required slot, so it gets picked automatically. This annotation makes that intent explicit rather than relying on the fallback heuristic.

## Notes

- No functional change — generators already handle this correctly via inference
- The derived artifacts (`meta.jsonld`, `meta.owl.ttl`) already contain this annotation from a prior manual edit; this brings the source YAML into sync

EDIT: @matentzn added this PR description in the hope that it reflects @cmungall original intend.