### PR TITLE
Remove ifabsent: false on extra_slots

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1363,7 +1363,6 @@ slots:
         forbid all additional data (default) 
       - `range_expression: ...`  - allow additional data if it matches the slot expression (see examples)
     domain: class_definition
-    ifabsent: false
     range: extra_slots_expression
     in_subset:
       - SpecificationSubset


### PR DESCRIPTION
Reason: this is invalid, the range of extra_slots is
an extra_slots_expression.

i.e

```yaml
extra_slots:
  allowed: false
```

not:

```yaml
extra_slots: false
```
