### PR TITLE
Add w3curie type and edit def of curie to be less restrictive

### DIFF
--- a/linkml_model/model/schema/types.yaml
+++ b/linkml_model/model/schema/types.yaml
@@ -31,7 +31,7 @@ types:
     base: str
     description: A character string
     notes: >-
-      In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.  
+      In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.
       If you are authoring schemas in LinkML YAML, the type is referenced with the lower case "string".
     exact_mappings:
       - schema:Text
@@ -132,14 +132,24 @@ types:
 
   curie:
     uri: xsd:string
+    base: URIorCURIE
+    repr: str
+    description: a prefixed ID, which may or may not conform to the w3 CURIE spec.
+    comments:
+      - Allows a wider range of characters than the stricter w3curie type.
+    notes: >-
+      If you are authoring schemas in LinkML YAML, the type is referenced with the lower case "curie".
+
+  w3curie:
+    uri: xsd:string
     base: Curie
     repr: str
-    description: a compact URI
+    description: A compact URI with a restricted character set; conforms to the w3 CURIE spec.
     comments:
       - in RDF serializations this MUST be expanded to a URI
       - in non-RDF serializations MAY be serialized as the compact representation
     notes: >-
-      If you are authoring schemas in LinkML YAML, the type is referenced with the lower case "curie".
+      If you are authoring schemas in LinkML YAML, the type is referenced with the lower case "w3curie".
     conforms_to: https://www.w3.org/TR/curie/
 
   uri:


### PR DESCRIPTION
Adding in the new w3curie type.

I tried to update the repo to use py3.12 with the current versions of linkml, linkml-runtime, and pyyaml so that I could regenerate the project files. Run `make gen-project` gave the following output:

```sh
# for all the files in the schema folder, run the gen-python command and output the result to the top
# level of the project.  In other repos, we'd include mergeimports=True, but we don't do that with
# linkml-model.
ValueError:  Unknown argument: slot_usage = {'dimensions': {'equals_number': 1}}
ValueError:  type "any_number" must declare a type base or parent (typeof)
cp staging/*.py linkml_model
poetry run gen-project -d staging --config-file gen_project_config.yaml linkml_model/model/schema/meta.yaml
Traceback (most recent call last):
[...snip a load of callback lines...]
ValueError: The ifabsent value `default_range` of the `range` slot could not be processed
make: *** [gen-project] Error 1
```

Looks like the various project generators, etc., have become more restrictive since `linkml-model` was last updated.