### PR TITLE
Fix equals_string on enum-ranged array_linearization_order

### DIFF
--- a/linkml_model/model/schema/array.yaml
+++ b/linkml_model/model/schema/array.yaml
@@ -89,7 +89,7 @@ classes:
       - array_linearization_order
     slot_usage:
       array_linearization_order:
-        equals_string: COLUMN_MAJOR_ARRAY_ORDER
+        ifabsent: "string(COLUMN_MAJOR_ARRAY_ORDER)"
 
   RowOrderedArray:
     mixin: true
@@ -100,7 +100,7 @@ classes:
       - array_linearization_order
     slot_usage:
       array_linearization_order:
-        equals_string: ROW_MAJOR_ARRAY_ORDER
+        ifabsent: "string(ROW_MAJOR_ARRAY_ORDER)"
 
 slots:
   dimensions:


### PR DESCRIPTION
Replace `equals_string` with `ifabsent` in `ColumnOrderedArray` and `RowOrderedArray` slot_usage. `equals_string` requires range `string`, not the `ArrayLinearizationOrderOptions` enum, which was causing a `ValueError` during `make all`:

Quick fix per @rly: unblocks the build and preserves enum semantics, but trades away the schema-level "must equal X" constraint — `ifabsent` only sets a default. Re-enforcing the constraint is a separate concern tracked upstream (relaxing `_check_equals_string` for enums, or wiring up `enum_range` across generators).

Refs: https://github.com/linkml/linkml/issues/3453