### PR TITLE
Resolve ambiguity on how to handle attributes

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -1231,11 +1231,11 @@ slots:
     multivalued: true
     range: slot_definition
     inlined: true
-    description: Inline definition of slots
+    description: Inline definition of class-scoped slots
     comments:
       - >-
-        attributes are an alternative way of defining new slots.  An attribute adds a slot to the global space in the
-        form <class_name>__<slot_name> (lower case, double underscores).  Attributes can be specialized via slot_usage.
+        Attributes are an alternative way of defining class-specific slots.
+        They are equivalent to slots that are only available within the scope of class and its descendants.
     in_subset:
       - SpecificationSubset
       - MinimalSubset


### PR DESCRIPTION
This patch fixes the `attributes` specification for more clarity on how to handle `attributes` converting to other formats.

Before this patch the `attributes` specification had a comment that gave the impression that `attributes` are only syntactic sugar for class-scoped slots (slots that are only available to be used by a class and its descendants) and specifying the conversion of `attributes` into `slots` renaming them to `<class-name>__<attribute-name>`.

This patch modifies that comment so that `attributes` are kept as 1st-class-citizens even on conversions.

Fixes: linkml/linkml#3669