### PR TITLE
fix: `status`'s range is `string` instead of `uriorcurie`

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -434,11 +434,13 @@ slots:
     aliases:
       - workflow status
     domain: element
-    range: uriorcurie
+    range: string
     description: status of the element
-    slot_uri: bibo:status
+    close_mappings:
+      - bibo:status
     examples:
-      - value: "bibo:draft"
+      - value: "testing"
+      - value: "unstable"
     see_also:
       - https://www.hl7.org/fhir/valueset-publication-status.html  ## Draft, Active, Retired, Unknown
       - https://www.hl7.org/fhir/versions.html#std-process  ## Draft, Trial Use, Normative, Informative, Deprecated


### PR DESCRIPTION
The slot `status` declares it's range to be `uriorcurie`, but in fact bare strings like `testing` or `unstable` are being used in the metamodel itself (more details in the below linked issue). This patch aligns the specification with its current use.

Fixing it to remain `uriorcurie` would require multiple changes with bigger impact than this change. They might get implemented in the future.

Fixes: https://github.com/linkml/linkml/issues/3760