### PR TITLE
test(pre-commit): exclude gen-project artefact failures we cannot control

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,26 @@
 default_language_version:
   python: python3
 
+# Note: the `exclude` patterns below cover `make gen-project` outputs written
+# into linkml_model/ which we do not control. Artefacts copied verbatim from the
+# LinkML generators, which emit trailing whitespace and inconsistent final
+# newlines (e.g. the bare "// " comment line in protobuf/meta.proto). Native
+# sources stay covered: model/schema/, model/docs/, linkml_files.py, etc.
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
+    exclude: &generated-artefacts |
+      (?x)^linkml_model/(
+        (excel|graphql|jsonld|jsonschema|owl|prefixmap|protobuf|rdf|shacl|shex|sqlddl|sqlschema)/
+        |(annotations|array|datasets|extensions|mappings|meta|types|units|validation)\.py$
+      )
   - id: check-yaml
   - id: check-toml
   - id: trailing-whitespace
+    exclude: *generated-artefacts
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.1


### PR DESCRIPTION
This PR is to stop CI failures for `gen-project` generated output (which `linkml-model` does not control):

Excluded quality hooks:

- `end-of-file-fixer`
- `trailing-whitespaces`

Excluded generated content:

- excel/ graphql/ jsonld/ jsonschema/ owl/ prefixmap/ protobuf/ rdf/ shacl/ shex/ sqlddl/ sqlschema/
- annotations array datasets extensions mappings meta types units validation .py

See: https://github.com/linkml/linkml-model/actions/runs/30282095966/job/90030765962