### PR TITLE
fix(tests): nest structured annotation payload under `value`

### DIFF
--- a/tests/input/examples/schema_definition-native-array-1.yaml
+++ b/tests/input/examples/schema_definition-native-array-1.yaml
@@ -20,13 +20,17 @@ classes:
   TemperatureDataset:
     tree_root: true
     annotations:
+      # An annotation is a tag/value pair. A structured payload must be nested
+      # under `value` (range AnyValue); keys placed directly under the tag are
+      # otherwise read as slots of Annotation itself.
       array_data_mapping:
-        data: temperatures_in_K
-        dims: [x, y, t]
-        coords:
-          latitude_in_deg: x
-          longitude_in_deg: y
-          time_in_d: t
+        value:
+          data: temperatures_in_K
+          dims: [x, y, t]
+          coords:
+            latitude_in_deg: x
+            longitude_in_deg: y
+            time_in_d: t
     attributes:
       name:
         identifier: true

--- a/tests/input/examples/schema_definition-structured-annotations.yaml
+++ b/tests/input/examples/schema_definition-structured-annotations.yaml
@@ -1,0 +1,48 @@
+id: https://example.org/structured-annotations
+name: structured-annotations-example
+title: Structured Annotations Example
+description: |-
+  Example LinkML schema exercising the annotation forms accepted by the
+  metamodel: simple tag/value pairs, structured payloads nested under
+  `value`, and annotations that carry their own nested annotations.
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  example: https://example.org/
+
+default_prefix: example
+
+imports:
+  - linkml:types
+
+classes:
+
+  Sample:
+    tree_root: true
+    annotations:
+      # simple tag/value pair
+      display_hint: table
+      # structured payload must be nested under `value` (range AnyValue)
+      provenance:
+        value:
+          source: https://example.org/source-db
+          retrieved_on: "2026-08-05"
+          pipeline:
+            name: ingest
+            version: 1.2.3
+      # an annotation may itself be annotated
+      review_status:
+        value: approved
+        annotations:
+          reviewed_by: curator-team
+    attributes:
+      name:
+        identifier: true
+        range: string
+      measurement:
+        range: float
+        annotations:
+          units_note:
+            value:
+              system: SI
+              quantity: mass

--- a/tests/test_input_against_model.py
+++ b/tests/test_input_against_model.py
@@ -20,6 +20,7 @@ class InputFileTestCase(unittest.TestCase):
         pyaml, pjson, pttl = 0, 0, 0
         nunk = 0
         nread, nfailures = 0, 0
+        failures = []
         for dpath, _, files in os.walk(INPUT_DIR):
             for fname in files:
                 full_fname = os.path.join(dpath, fname)
@@ -41,8 +42,9 @@ class InputFileTestCase(unittest.TestCase):
                         pass
                     else:
                         nunk += 1
-                except Exception as _:
+                except Exception as e:
                     nfailures += 1
+                    failures.append(f"{os.path.relpath(full_fname, INPUT_DIR)}: {e}")
 
         print(f"{nread} files tested")
         print(f"\t{nread - nfailures} tests passed ({nfailures} failed)")
@@ -52,6 +54,7 @@ class InputFileTestCase(unittest.TestCase):
         print(f"\t\t{gen_detail(nttl, pttl, 'TTL')}")
         if nunk:
             print(f"{nunk} files of unrecognized type")
+        self.assertEqual(nfailures, 0, f"{nfailures} input file(s) failed to load:\n" + "\n".join(failures))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #https://github.com/linkml/linkml/issues/3809

- Nesting the payload under `value` (range AnyValue) preserves the structure and lets the file load
- Hard fail `tests/test_input_against_model.py` when counted failures