### PR TITLE
Fix spec links and duplicate generated docs

### DIFF
--- a/.github/workflows/build-publish-documentation.yaml
+++ b/.github/workflows/build-publish-documentation.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Generate markdown docs from schema
         run: uv run make gen-doc
 
+      - name: Build docs with mkdocs in strict mode
+        run: uv run make builddoc
+
       - name: Deploy generated docs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ serve: mkd-serve
 
 testdoc: gen-doc serve
 
-# --strict promotes mkdocs warnings (e.g., broken internal links) to errors, 
+# --strict promotes mkdocs warnings (e.g., broken internal links) to errors,
 # so CI fails on them.
 builddoc:
 	$(RUN) mkdocs build --strict

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ gen-sqlddl: $(DEST)
 gen-doc:
 	$(RUN) gen-doc --genmeta --sort-by rank -d $(DOCDIR)/docs $(SOURCE_SCHEMA_PATH)
 	cp -r linkml_model/model/docs/* $(DOCDIR)/docs
+	# the destination must be removed first, otherwise a re-run copies the
+	# source *into* the existing directory, yielding a nested $(PYMODEL)/$(PYMODEL)
+	rm -rf $(DOCDIR)/$(PYMODEL)
 	cp -r $(PYMODEL) $(DOCDIR)/$(PYMODEL)
 	rm -rf $(DOCDIR)/$(PYMODEL)/model/docs
 	cp README.md $(DOCDIR)
@@ -143,8 +146,10 @@ serve: mkd-serve
 
 testdoc: gen-doc serve
 
+# --strict promotes mkdocs warnings (e.g., broken internal links) to errors, 
+# so CI fails on them.
 builddoc:
-	$(RUN) mkdocs build
+	$(RUN) mkdocs build --strict
 
 MKDOCS = $(RUN) mkdocs
 mkd-%:

--- a/linkml_model/model/docs/specification/02instances.md
+++ b/linkml_model/model/docs/specification/02instances.md
@@ -6,7 +6,7 @@ This specification provides a grammar for a **functional syntax** for expressing
 
 This syntax is not intended for data exchange, but instead for unambiguous describing data in LinkML in a way that is independent of any particular syntax.
 
-[Section 6](../06mapping) specifies how the instance model is serialized as JSON, YAML, and RDF, and guidelines for mapping to object-oriented programming representations.
+[Section 6](06mapping.md) specifies how the instance model is serialized as JSON, YAML, and RDF, and guidelines for mapping to object-oriented programming representations.
 
 This section uses BNF to define the structure of the LinkML instance abstract model.
 We also include UML-style diagrams for informative purposes.
@@ -33,7 +33,7 @@ classDiagram
 
 ### Definition Types and Names
 
-Definition names are used to unambiguously indicate *elements* specified in a **Schema** (described in [Part 3](../03schemas)):
+Definition names are used to unambiguously indicate *elements* specified in a **Schema** (described in [Part 3](03schemas.md)):
 
 > **ClassDefinitionName** := **ElementName**
 
@@ -223,7 +223,7 @@ Examples of collections:
 * `[Person(name=..., ...), Integer^5, None]` -- a heterogeneous collection
 * `[]` -- an empty collection
 
-Note that collections can be serialized in different ways depending on the target syntax, for examples, lists vs dictionaries. See section [6](../06mapping) for details of serializations.
+Note that collections can be serialized in different ways depending on the target syntax, for examples, lists vs dictionaries. See section [6](06mapping.md) for details of serializations.
 
 ### None (Null) instances
 

--- a/linkml_model/model/docs/specification/03schemas.md
+++ b/linkml_model/model/docs/specification/03schemas.md
@@ -37,7 +37,7 @@ This part of the specification specifies schemas in terms of the abstract functi
 
 For practical purposes, the canonical serialization of a schema is in YAML. The rules for serializing and deserializing LinkML schemas are the same as for instances, because every schema is an object that instantiates a SchemaDefinition class in the metamodel.
 
-See  [section 6](06mapping) for rules for mapping to YAML.
+See  [section 6](06mapping.md) for rules for mapping to YAML.
 
 ### Analogies to other modeling frameworks
 

--- a/linkml_model/model/docs/specification/index.md
+++ b/linkml_model/model/docs/specification/index.md
@@ -2,10 +2,10 @@
 
 ## Table of Contents
 
-- [Preamble](00preamble)
-- [Introduction](01introduction)
-- [Instances](02instances)
-- [Schemas](03schemas)
-- [Derived Schemas](D04derived-schemas)
-- [Validation](05validation)
-- [Mapping](06mapping)
+- [Preamble](00preamble.md)
+- [Introduction](01introduction.md)
+- [Instances](02instances.md)
+- [Schemas](03schemas.md)
+- [Derived Schemas](04derived-schemas.md)
+- [Validation](05validation.md)
+- [Mapping](06mapping.md)


### PR DESCRIPTION
- Fix broken link in specification index.md
- Write the links with the .md extension so that mkdocs can catch broken links
- Fix `make gen-doc` generating increasingly nested `linkml_model` directories in `docs/`, which causes a mess in local development
- Add an mkdocs build to PR CI so that broken internal links are caught in CI