### PR TITLE
Add langstring support to the metamodel

### DIFF
--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -171,6 +171,8 @@ slots:
     slot_uri: dcterms:title
     in_subset:
       - BasicSubset
+    todos:
+      - Change the range to langstring
 
   conforms_to:
     domain: element
@@ -271,6 +273,8 @@ slots:
     recommended: true
     in_subset:
       - BasicSubset
+    todos:
+      - Change the range to langstring
 
   structured_aliases:
     slot_uri: skosxl:altLabel

--- a/linkml_model/model/schema/types.yaml
+++ b/linkml_model/model/schema/types.yaml
@@ -165,6 +165,31 @@ types:
     notes: >-
       If you are authoring schemas in LinkML YAML, the type is referenced with the lower case "ncname".
 
+  langstring:
+    uri: linkml:LocalizedText
+    base: LocalizedText
+    description: >-
+      String with optional localization variants. Either a plain, non-langauge-tagged string or a multi-language mapping with at least one value.
+      Defines 2 operations that allow converting to a single string: 'plain()' and 'in_language(tag)'.
+    notes:
+      - In JSON serializations, plain strings should be mapped to JSON strings, and multi-language strings should be represented as a dictionary object of a language tag to a value in that language.
+      - In RDF serializations, plain strings should be mapped to xsd:string, and multi-language strings to rdf:langString with appropriate language tags.
+      - |
+        'plain()' yields a string that is populated from:
+        (1) the plain text if available,
+        (2) the English text if available, or
+        (3) the text of the alphabetically first language tag.
+      - |
+        'in_language(tag)' yields a string that is populated from:
+        (1) the plain text if available,
+        (2) the text of the specified language if available,
+        (3) the English text if available, or
+        (4) the text of the alphabetically first language tag.
+
+    todos:
+      - Implement support for the type in linkml_runtime
+      - Decide the base/repr slots of this type
+
   objectidentifier:
     uri: shex:iri
     base: ElementIdentifier


### PR DESCRIPTION
Issue linkml/linkml#3548 and a dozen others

  This PR adds the definitions and the documentation of a new `langstring` type which will provide the necessary infrastructure for implementing multi-lingual support for schema metadata. This PR does not yet change the metamodel metadata slots to use the type - but `title` and `description` are marked as candidates.

  **Justification**
  Lack of first class support for multilinguality in LinkML has been a big pain point for us.  Adding external tooling would work for now, and I can see it being a useful feature on its own, but **this is something that should   be enabled by the metamodel, not done in spite of it.**   Multi-linguality is a hard requirement in the EU, often enforced by law.   Web has moved on to being multi-lingual by default: multi-linguality is required by W3C in all standards.    For LinkML to be useful for ontology writing, this is badly needed.

  **Functionality**
  `langstring` values are a union of `plain` strings (non-language-tagged), and `multi-language` strings (language tagged, with at least one language). `plain` strings are treated as such - they do not specify language information and are assumed to always be something that should be displayed to the user. `multi-language` strings are a mapping of a language tag to the appropriate text, localized in the specified language.

  **Serializations**
Copied from the notes:
  - In JSON serializations, plain strings should be mapped to JSON strings, and multi-language strings should be represented as a dictionary object of a language tag key to a text value in that language.
  - In RDF serializations, plain strings should be mapped to xsd:string, and multi-language strings to rdf:langString with appropriate language tags.

Examples:

- JSON `"some text"` becomes RDF `"some text"^^xsd:string`
- JSON `{ "en": "some text", "pl": "jakiś tekst" }` becomes RDF `"some text"@en` and `"jakiś tekst"@pl`

**Runtime behavior**
Copied from the notes:
  - `plain()` yields a string that is populated from: (1) the plain text if available, (2) the English text if available, or (3) the text of the alphabetically first language tag.
  - `in_language(tag)` yields a string that is populated from: (1) the plain text if available, (2) the text of the specified language if available, (3) the English text if available, or (4) the text of the alphabetically first language tag.

  **Rationale for making `langstring` a magic type**
  We've seen the approaches proposed by linkml-adjacent projects, but we have opted to go for the simplest option that would work for metadata. Given the constraints:
  - not break every single LinkML schema in existence,
  - not force people to use multi-lingual metadata if they don't need it,
  - provide generators a clean migration path.

  To implement something that would satisfy all of these constraints generically (while allowing it to be used in "regular" schemas as well) would require a lot more effort in the metamodel, which would probably not be useful outside of this specific application. Let's not add 5 new boolean slots for this

  **Additional context**
  We have this implemented fully in [LinkML-Scala](https://github.com/NeverBlink-OSS/linkml-scala). See the demo in the playground [here](https://linkml.neverblink.eu/playground/?url=https%3A%2F%2Fgist.githubusercontent.com%2FOstrzyciel%2F49d21c31df0f632bc36810cdf5ee4025%2Fraw%2F6372c36a921493c6471635d1c0a0f36c05c8e2de%2Fmultilingual.yaml) and the code [here](https://github.com/NeverBlink-OSS/linkml-scala/blob/main/runtime/src/eu/neverblink/linkml/runtime/LocalizedText.scala)

  I think an alternative approach would be to make langstrings a magic class like linkml:Any, as opposed to a type, which would preserve the "types are always atomic values" assumption.

  **Future considerations**
  I think in_language slot should control the language of the `plain` string, but it would require careful scoping and other considerations for this to work well. This would allow for example
  
  ```
in_language: en
title: My thing
  ```
  
  to mean `"My thing"@en` in RDF
