### PR TITLE
De-space case the LinkML metamodel

### DIFF
--- a/linkml_model/model/schema/mappings.yaml
+++ b/linkml_model/model/schema/mappings.yaml
@@ -45,60 +45,67 @@ slots:
       related but not equivalent from a strict ontological perspective.
     slot_uri: skos:mappingRelation
 
-  exact mappings:
+  exact_mappings:
     is_a: mappings
     range: uriorcurie
+    title: exact mappings
     multivalued: true
     inherited: false
     description: >-
       A list of terms from different schemas or terminology systems that have identical meaning.
     slot_uri: skos:exactMatch
 
-  close mappings:
+  close_mappings:
     is_a: mappings
     range: uriorcurie
+    title: close mappings
     multivalued: true
     inherited: false
     description: >-
       A list of terms from different schemas or terminology systems that have close meaning.
     slot_uri: skos:closeMatch
 
-  related mappings:
+  related_mappings:
     is_a: mappings
     range: uriorcurie
+    title: related mappings
     multivalued: true
     inherited: false
     description: >-
       A list of terms from different schemas or terminology systems that have related meaning.
     slot_uri: skos:relatedMatch
 
-  narrow mappings:
+  narrow_mappings:
     is_a: mappings
     range: uriorcurie
+    title: narrow mappings
     multivalued: true
     inherited: false
     description: >-
       A list of terms from different schemas or terminology systems that have narrower meaning.
     slot_uri: skos:narrowMatch
 
-  broad mappings:
+  broad_mappings:
     is_a: mappings
     range: uriorcurie
+    title: broad mappings
     multivalued: true
     inherited: false
     description: >-
       A list of terms from different schemas or terminology systems that have broader meaning.
     slot_uri: skos:broadMatch
 
-  deprecated element has exact replacement:
+  deprecated_element_has_exact_replacement:
     range: uriorcurie
+    title: deprecated element has exact replacement
     description: >-
       When an element is deprecated, it can be automatically replaced by this uri or curie
     mappings:
       - IAO:0100001
 
-  deprecated element has possible replacement:
+  deprecated_element_has_possible_replacement:
     range: uriorcurie
+    title: deprecated element has possible replacement
     description: >-
       When an element is deprecated, it can be potentially replaced by this uri or curie
     mappings:

--- a/linkml_model/model/schema/meta.yaml
+++ b/linkml_model/model/schema/meta.yaml
@@ -2593,16 +2593,16 @@ classes:
       - source
       - in_language
       - see_also
-      - deprecated element has exact replacement
-      - deprecated element has possible replacement
+      - deprecated_element_has_exact_replacement
+      - deprecated_element_has_possible_replacement
       - aliases
       - structured_aliases
       - mappings
-      - exact mappings
-      - close mappings
-      - related mappings
-      - narrow mappings
-      - broad mappings
+      - exact_mappings
+      - close_mappings
+      - related_mappings
+      - narrow_mappings
+      - broad_mappings
       - created_by
       - contributors
       - created_on

--- a/linkml_model/model/schema/units.yaml
+++ b/linkml_model/model/schema/units.yaml
@@ -74,13 +74,13 @@ classes:
       - symbol
       - abbreviation
       - descriptive_name
-      - exact mappings
+      - exact_mappings
       - ucum_code
       - derivation
       - has_quantity_kind
       - iec61360code
     slot_usage:
-      exact mappings:
+      exact_mappings:
         description: Used to link a unit to equivalent concepts in ontologies such as UO, SNOMED, OEM, OBOE, NCIT
         comments:
           - Do not use this to encode mappings to systems for which a dedicated field exists


### PR DESCRIPTION
Issue https://github.com/linkml/linkml/issues/3968

There is not really a reason to keep space casing in the metamodel. This adds annoying and unnecessary complexity, as it is implicitly converted to underscores anyway, as far as I'm aware.